### PR TITLE
use connector id to identify

### DIFF
--- a/ui/packages/models/src/ui.model.ts
+++ b/ui/packages/models/src/ui.model.ts
@@ -70,6 +70,7 @@ export interface ConnectorProperty {
  */
 // tslint:disable-next-line: interface-name
 export interface ConnectorType {
+    id: string;
     className: string;
     displayName: string;
     version: string;

--- a/ui/packages/services/src/connector/connector.service.ts
+++ b/ui/packages/services/src/connector/connector.service.ts
@@ -25,6 +25,23 @@ import {BaseService} from "../baseService";
  */
 export class ConnectorService extends BaseService {
 
+    /**
+     * Validate the connection properties for the supplied connection type
+     * Example usage:
+     * 
+     * const connectorService = Services.getConnectorService();
+     * const inputMap = new Map<string,string>();
+     * inputMap.set("oneParam","oneValue");
+     * inputMap.set("twoParam","twoValue");
+     * connectorService.validateConnection('postgres', inputMap)
+     *  .then((result: ConnectionValidationResult) => {
+     *    if (result.status === 'INVALID') {
+     *      alert('status is INVALID');
+     *    } else {
+     *      alert('status is VALID');
+     *    }
+     *  });
+     */
     public validateConnection(connectorTypeId: string, input: Map<string, string>): Promise<ConnectionValidationResult> {
         this.logger.info("[ConnectorService] Validating connection:", connectorTypeId);
 
@@ -35,6 +52,23 @@ export class ConnectorService extends BaseService {
         return this.httpPostWithReturn(endpoint, body);
     }
 
+    /**
+     * Validate the filters for the supplied connection type
+     * Example usage:
+     * 
+     * const connectorService = Services.getConnectorService();
+     * const inputMap = new Map<string,string>();
+     * inputMap.set("oneParam","oneValue");
+     * inputMap.set("twoParam","twoValue");
+     * connectorService.validateFilters('postgres', inputMap)
+     *  .then((result: FilterValidationResult) => {
+     *    if (result.status === 'INVALID') {
+     *      alert('status is INVALID');
+     *    } else {
+     *      alert('status is VALID');
+     *    }
+     *  });
+     */
     public validateFilters(connectorTypeId: string, input: Map<string, string>): Promise<FilterValidationResult> {
         this.logger.info("[ConnectorService] Validating filters:", connectorTypeId);
 
@@ -45,6 +79,23 @@ export class ConnectorService extends BaseService {
         return this.httpPostWithReturn(endpoint, body);
     }
 
+    /**
+     * Validate the properties for the supplied connection type
+     * Example usage:
+     * 
+     * const connectorService = Services.getConnectorService();
+     * const inputMap = new Map<string,string>();
+     * inputMap.set("oneParam","oneValue");
+     * inputMap.set("twoParam","twoValue");
+     * connectorService.validateProperties('postgres', inputMap)
+     *  .then((result: PropertiesValidationResult) => {
+     *    if (result.status === 'INVALID') {
+     *      alert('status is INVALID');
+     *    } else {
+     *      alert('status is VALID');
+     *    }
+     *  });
+     */
     public validateProperties(connectorTypeId: string, input: Map<string, string>): Promise<PropertiesValidationResult> {
         this.logger.info("[ConnectorService] Validating properties:", connectorTypeId);
 

--- a/ui/packages/ui/src/app/pages/connectors/ConnectorIcon.tsx
+++ b/ui/packages/ui/src/app/pages/connectors/ConnectorIcon.tsx
@@ -4,7 +4,7 @@ import MongoIcon from '../../../../assets/images/mongodb-128x128.png'
 import MySqlIcon from '../../../../assets/images/mysql-170x115.png'
 import PostgresIcon from '../../../../assets/images/PostgreSQL-120x120.png'
 import SqlServerIcon from '../../../../assets/images/sql-server-144x144.png'
-import { ConnectorTypeClass } from 'src/app/shared';
+import { ConnectorTypeId } from 'src/app/shared';
 
 export interface IConnectorIconProps {
   connectorType: string;
@@ -19,13 +19,13 @@ export const ConnectorIcon: React.FunctionComponent<IConnectorIconProps> = (
 ) => {
 
   let connIcon = null;
-  if (props.connectorType === ConnectorTypeClass.MYSQL) {
+  if (props.connectorType === ConnectorTypeId.MYSQL) {
     connIcon = MySqlIcon;
-  } else if(props.connectorType === ConnectorTypeClass.POSTGRES) {
+  } else if(props.connectorType === ConnectorTypeId.POSTGRES) {
     connIcon = PostgresIcon;
-  } else if(props.connectorType === ConnectorTypeClass.SQLSERVER) {
+  } else if(props.connectorType === ConnectorTypeId.SQLSERVER) {
     connIcon = SqlServerIcon;
-  } else if(props.connectorType === ConnectorTypeClass.MONGO) {
+  } else if(props.connectorType === ConnectorTypeId.MONGO) {
     connIcon = MongoIcon;
   }
 

--- a/ui/packages/ui/src/app/pages/connectors/ConnectorsPage.tsx
+++ b/ui/packages/ui/src/app/pages/connectors/ConnectorsPage.tsx
@@ -17,7 +17,7 @@ import { Link } from "react-router-dom";
 import "./ConnectorsPage.css";
 import { Connector } from "@debezium/ui-models";
 import { ConnectorListItem } from "./ConnectorListItem";
-import { ConnectorTypeClass } from "src/app/shared";
+import { ConnectorTypeId } from "src/app/shared";
 
 /**
  * Sorts the connectors by name.
@@ -39,26 +39,26 @@ export const ConnectorsPage: React.FunctionComponent = () => {
       {
         name: "mongoTest",
         description: "MongoDB connector",
-        type: ConnectorTypeClass.MONGO
+        type: ConnectorTypeId.MONGO
       } as Connector,
       {
         name: "postgresTest",
         description: "PostgreSQL connector",
-        type: ConnectorTypeClass.POSTGRES
+        type: ConnectorTypeId.POSTGRES
       } as Connector,
       {
         name: "mySqlTest",
         description: "MySQL connector",
-        type: ConnectorTypeClass.MYSQL
+        type: ConnectorTypeId.MYSQL
       } as Connector,
       {
         name: "sqlServerTest",
         description: "SqlServer connector",
-        type: ConnectorTypeClass.SQLSERVER
+        type: ConnectorTypeId.SQLSERVER
       } as Connector
     ] as Connector[]
   );
-
+  
   return (
     <PageSection>
       <Flex>

--- a/ui/packages/ui/src/app/pages/createConnector/CreateConnectorPage.tsx
+++ b/ui/packages/ui/src/app/pages/createConnector/CreateConnectorPage.tsx
@@ -80,8 +80,8 @@ export const CreateConnectorPage: React.FunctionComponent = () => {
   // Init the selected connector type to first 'enabled' connectortype
   React.useEffect(() => {
     // tslint:disable-next-line: no-unused-expression
-    connectorTypes[0]?.className &&
-    setSelectedConnectorType(connectorTypes[0].className);
+    connectorTypes[0]?.id &&
+    setSelectedConnectorType(connectorTypes[0].id);
   }, [connectorTypes]);
 
   const wizardSteps = [

--- a/ui/packages/ui/src/app/pages/createConnector/connectorSteps/SelectConnectorTypeComponent.tsx
+++ b/ui/packages/ui/src/app/pages/createConnector/connectorSteps/SelectConnectorTypeComponent.tsx
@@ -18,7 +18,7 @@ import { ConnectorIcon } from "../../connectors/ConnectorIcon";
 
 export interface ISelectConnectorTypeComponentProps {
   selectedConnectorType?: string;
-  onSelectionChange: (connectorType: string | undefined) => Promise<void>;
+  onSelectionChange: (connectorType: string | undefined) => void;
   connectorTypesList: ConnectorType[];
   loading: boolean;
   apiError: boolean;
@@ -32,7 +32,7 @@ export const SelectConnectorTypeComponent: React.FunctionComponent<ISelectConnec
     // The id is the connector className
     const newId = event.currentTarget.id;
     const selectedConn = props.connectorTypesList.find(
-      (cType) => cType.className === newId
+      (cType) => cType.id === newId
     );
 
     // Set selection undefined if connector is not enabled or no change in type (deselection)
@@ -58,18 +58,18 @@ export const SelectConnectorTypeComponent: React.FunctionComponent<ISelectConnec
               className={"select-connector-type-component_cardItem"}
             >
               <Card
-                id={cType.className}
+                id={cType.id}
                 // tslint:disable-next-line: no-empty
                 onClick={cType.enabled ? onCardSelection : ()=>{}}
                 isSelectable={cType.enabled}
-                isSelected={props.selectedConnectorType === cType.className}
+                isSelected={props.selectedConnectorType === cType.id}
                 className={!cType.enabled ? 'select-connector-type-component_disableCard' : ''}
               >
                 <CardHeader>
                   <CardHeaderMain
                     className={"select-connector-type-component_dbIcon"}
                   >
-                    <ConnectorIcon connectorType={cType.className} alt={cType.displayName} width={50} />
+                    <ConnectorIcon connectorType={cType.id} alt={cType.displayName} width={50} />
                   </CardHeaderMain>
                 </CardHeader>
                 <CardTitle>{cType.displayName}</CardTitle>

--- a/ui/packages/ui/src/app/shared/Utils.ts
+++ b/ui/packages/ui/src/app/shared/Utils.ts
@@ -1,10 +1,10 @@
 import { ConnectorType } from "@debezium/ui-models";
 
-export enum ConnectorTypeClass {
-  POSTGRES = "io.debezium.connector.postgresql.PostgresConnector",
-  MYSQL = "io.debezium.connector.mysql.MySqlConnector",
-  SQLSERVER = "io.debezium.connector.sqlserver.SqlServerConnector",
-  MONGO = "io.debezium.connector.mongodb.MongoDbConnector",
+export enum ConnectorTypeId {
+  POSTGRES = "postgres",
+  MYSQL = "mysql",
+  SQLSERVER = "sqlserver",
+  MONGO = "mongodb",
 }
 
 /**
@@ -13,17 +13,17 @@ export enum ConnectorTypeClass {
 const MAX_RETRIES: number = 5;
 
 /**
- * Get a description of the ConnectorType, based on the class
+ * Get a description of the ConnectorType, based on the id
  * @param connType the connector type
  */
 export function getConnectorTypeDescription(connType: ConnectorType): string {
-  if (connType.className === ConnectorTypeClass.MYSQL) {
+  if (connType.id === ConnectorTypeId.MYSQL) {
     return "MySQL database";
-  } else if(connType.className === ConnectorTypeClass.POSTGRES) {
+  } else if(connType.id === ConnectorTypeId.POSTGRES) {
     return "PostgreSQL database";
-  } else if(connType.className === ConnectorTypeClass.SQLSERVER) {
+  } else if(connType.id === ConnectorTypeId.SQLSERVER) {
     return "SQLServer database";
-  } else if(connType.className === ConnectorTypeClass.MONGO) {
+  } else if(connType.id === ConnectorTypeId.MONGO) {
     return "MongoDB database";
   }
   return "Unknown type";


### PR DESCRIPTION
I missed that there was an id on the ConnectorType in my initial commit.  Better to identify ConnectorType by the id vs the longer classname - so I added the id to the model, then converted the usages.  Also added some comments in ConnectorService