### PR TITLE
Supply ConnectorProperties to components

### DIFF
--- a/ui/packages/models/src/ui.model.ts
+++ b/ui/packages/models/src/ui.model.ts
@@ -27,6 +27,15 @@ export interface Connector {
 }
 
 /**
+ * Model which represents the configuration for a connector
+ */
+// tslint:disable-next-line: interface-name
+export interface ConnectorConfiguration {
+    name: string;
+    config: Map<string,string>;
+}
+
+/**
  * Model which represents a property validation result
  */
 // tslint:disable-next-line: interface-name
@@ -59,6 +68,7 @@ export interface ConnectionValidationResult {
  */
 // tslint:disable-next-line: interface-name
 export interface ConnectorProperty {
+    category?: 'PROPS_BASIC' | 'PROPS_ADVANCED' | 'FILTERS';
     description: string;
     displayName: string;
     name: string;

--- a/ui/packages/services/src/connector/connector.service.ts
+++ b/ui/packages/services/src/connector/connector.service.ts
@@ -106,4 +106,27 @@ export class ConnectorService extends BaseService {
         return this.httpPostWithReturn(endpoint, body);
     }
 
+    /**
+     * Create Connector using the supplied ConnectorConfiguration
+     * Example usage:
+     * 
+     * const connectorService = Services.getConnectorService();
+     * const configMap = new Map<string,string>();
+     * configMap.set("oneParam","oneValue");
+     * configMap.set("twoParam","twoValue");
+     * const config = new ConnectorConfiguration("connName", configMap);
+     * connectorService.createConnector(config)
+     *  .then((result: CreateConnectorResult) => {
+     *  });
+     */
+    // public createConnector(connectorConfig: ConnectorConfiguration): Promise<PropertiesValidationResult> {
+    //     this.logger.info("[ConnectorService] Creating a connector:", connectorConfig.name);
+
+    //     const endpoint: string = this.endpoint("/connector-types/:connectorTypeId/validation/properties", { connectorTypeId });
+    //     const body = {
+    //         input
+    //     };
+    //     return this.httpPostWithReturn(endpoint, body);
+    // }
+
 }

--- a/ui/packages/ui/src/app/pages/createConnector/connectorSteps/ConfigureConnectorTypeComponent.tsx
+++ b/ui/packages/ui/src/app/pages/createConnector/connectorSteps/ConfigureConnectorTypeComponent.tsx
@@ -1,31 +1,19 @@
+import { ConnectorProperty } from "@debezium/ui-models";
 import * as React from 'react';
-import { PageLoader } from "src/app/component";
-import { ApiError } from "src/app/shared";
-import { WithLoader } from "src/app/shared/WithLoader";
 import './ConfigureConnectorTypeComponent.css'
 import { ConfigureConnectorTypeForm } from './ConfigureConnectorTypeForm';
 
 export interface IConfigureConnectorTypeComponentProps{
-  selectedConnectorType?: string;
-  connectorTypesList?: object;
-  loading: boolean;
-  apiError: boolean;
-  errorMsg: Error;
+  basicPropertyDefinitions: ConnectorProperty[];
+  basicPropertyValues: Map<string,string>;
+  advancedPropertyDefinitions: ConnectorProperty[];
+  advancedPropertyValues: Map<string,string>;
+  onValidateProperties: (connectorProperties: Map<string,string>) => void;
+  onSaveProperties: (connectorProperties: Map<string,string>) => void;
 }
 
 export const ConfigureConnectorTypeComponent: React.FC<IConfigureConnectorTypeComponentProps> = (props) => {
-  const {apiError, loading, errorMsg} = props;
- 
   return (
-    <WithLoader
-    error={apiError}
-    loading={loading}
-    loaderChildren={<PageLoader />}
-    errorChildren={<ApiError error={errorMsg} />}
-  >
-    {() => (
-      <ConfigureConnectorTypeForm />
-    )}
-  </WithLoader>
+    <ConfigureConnectorTypeForm />
   );
 }

--- a/ui/packages/ui/src/app/pages/createConnector/connectorSteps/FiltersStepComponent.tsx
+++ b/ui/packages/ui/src/app/pages/createConnector/connectorSteps/FiltersStepComponent.tsx
@@ -1,3 +1,4 @@
+import { ConnectorProperty } from "@debezium/ui-models";
 import {
   Button,
   Divider,
@@ -15,10 +16,17 @@ import React from "react";
 import "./FiltersStepComponent.css";
 
 // tslint:disable-next-line: no-empty-interface
-export interface IFiltersStepComponentProps {}
+export interface IFiltersStepComponentProps {
+  propertyDefinitions: ConnectorProperty[];
+  propertyValues: Map<string,string>;
+  onValidateProperties: (connectorProperties: Map<string,string>) => void;
+  onSaveProperties: (connectorProperties: Map<string,string>) => void;
+}
+
 export const FiltersStepComponent: React.FunctionComponent<IFiltersStepComponentProps> = (
   props
 ) => {
+
   return (
     <>
       <Title headingLevel="h2" size="3xl">

--- a/ui/packages/ui/src/app/shared/Utils.ts
+++ b/ui/packages/ui/src/app/shared/Utils.ts
@@ -1,10 +1,17 @@
-import { ConnectorType } from "@debezium/ui-models";
+import { ConnectorConfiguration, ConnectorType } from "@debezium/ui-models";
+import { ConnectorProperty } from '@debezium/ui-models';
 
 export enum ConnectorTypeId {
   POSTGRES = "postgres",
   MYSQL = "mysql",
   SQLSERVER = "sqlserver",
   MONGO = "mongodb",
+}
+
+export enum PropertyCategory {
+  PROPS_BASIC = "PROPS_BASIC",
+  PROPS_ADVANCED = "PROPS_ADVANCED",
+  FILTERS = "FILTERS",
 }
 
 /**
@@ -27,6 +34,74 @@ export function getConnectorTypeDescription(connType: ConnectorType): string {
     return "MongoDB database";
   }
   return "Unknown type";
+}
+
+/**
+ * Get a new ConnectorConfiguration for the specified ConnectorType
+ * @param connType the connector type
+ */
+export function newConnectorConfiguration(connectorType: ConnectorType): ConnectorConfiguration {
+  let connectorConfig = null;
+  if (connectorType) {
+    connectorConfig = { 
+      "name": "tempName",
+      "config": {
+        "connector.class": connectorType.className
+      }
+    } as ConnectorConfiguration;
+  }
+  return connectorConfig;
+}
+
+/**
+ * Get property definitions for the supplied category
+ * @param propertyDefns the array of all ConnectorProperty objects
+ * @param category the category for narrowing the ConnectorProperty objects
+ */
+export function getPropertyDefinitions(propertyDefns: ConnectorProperty[], category: PropertyCategory): ConnectorProperty[] {
+  const connProperties: ConnectorProperty[] = [];
+  for (const propDefn of propertyDefns) {
+    if (isInCategory(propDefn, category)) {
+      connProperties.push(propDefn);
+    }
+  }
+  return connProperties;
+}
+
+export function isInCategory(propertyDefn: ConnectorProperty, category: PropertyCategory) {
+  if (category === PropertyCategory.PROPS_BASIC && 
+    ( propertyDefn.name === 'database.server.name' ||
+      propertyDefn.name === 'database.dbname' ||
+      propertyDefn.name === 'database.hostname' ||
+      propertyDefn.name === 'database.port' ||
+      propertyDefn.name === 'database.user' ||
+      propertyDefn.name === 'database.password')
+    ) {
+    return true;
+  } else if (category === PropertyCategory.PROPS_ADVANCED && 
+    ( propertyDefn.name === 'database.tcpKeepAlive' ||
+      propertyDefn.name === 'database.initial.statements' ||
+      propertyDefn.name === 'plugin.name' ||
+      propertyDefn.name === 'publication.name' ||
+      propertyDefn.name === 'publication.autocreate.mode' ||
+      propertyDefn.name === 'slot.name' ||
+      propertyDefn.name === 'slot.drop.on.stop' ||
+      propertyDefn.name === 'slot.stream.params' ||
+      propertyDefn.name === 'slot.max.retries' ||
+      propertyDefn.name === 'slot.retry.delay.ms')
+    ) {
+    return true;
+  } else if (category === PropertyCategory.FILTERS &&
+    ( propertyDefn.name === 'schema.whitelist' ||
+      propertyDefn.name === 'schema.blacklist' ||
+      propertyDefn.name === 'table.whitelist' ||
+      propertyDefn.name === 'table.blacklist' ||
+      propertyDefn.name === 'column.whitelist' ||
+      propertyDefn.name === 'column.blacklist')
+    ) {
+    return true;
+  }
+  return false;
 }
 
 /**


### PR DESCRIPTION
Some initial work on supplying the correct subset of ConnectorProperties to the relevant pages.
- added ConnectorConfiguration model.  This is the object that will be passed to the 'createConnector' service
- added optional 'category' attribute to ConnectorProperty (this is not used yet)
- added createConnector function to the service, but it's commented out/not used yet.
- the FiltersStepComponent/ConfigureConnectorTypeComponent have properties for setting the relevant ConnectorProperties.
- added functions in Utils which group the property definitions by 'category' for supplying to the components.  This will change once the backend(hopefully) is able to supply category info.
- Each component has 'onSaveProperties' and 'onValidateProperties'.  The config property name-value pairs can then be supplied, and the CreateConnectorPage is responsible for doing the save or validation.
