### PR TITLE
Using property optional category, connecting test validation

### DIFF
--- a/ui/packages/services/src/connector/connector.service.ts
+++ b/ui/packages/services/src/connector/connector.service.ts
@@ -16,7 +16,7 @@
  */
 
 import {
-    ConnectionValidationResult, FilterValidationResult, PropertiesValidationResult
+    ConnectionValidationResult, FilterValidationResult, PropertiesValidationResult, ConnectorConfiguration
 } from "@debezium/ui-models";
 import {BaseService} from "../baseService";
 
@@ -119,14 +119,14 @@ export class ConnectorService extends BaseService {
      *  .then((result: CreateConnectorResult) => {
      *  });
      */
-    // public createConnector(connectorConfig: ConnectorConfiguration): Promise<PropertiesValidationResult> {
-    //     this.logger.info("[ConnectorService] Creating a connector:", connectorConfig.name);
+    public createConnector(connectorConfig: ConnectorConfiguration): Promise<void> {
+        this.logger.info("[ConnectorService] Creating a connector:", connectorConfig.name);
 
-    //     const endpoint: string = this.endpoint("/connector-types/:connectorTypeId/validation/properties", { connectorTypeId });
-    //     const body = {
-    //         input
-    //     };
-    //     return this.httpPostWithReturn(endpoint, body);
-    // }
+        const endpoint: string = this.endpoint("/connector");
+        const body = {
+            connectorConfig
+        };
+        return this.httpPostWithReturn(endpoint, body);
+    }
 
 }

--- a/ui/packages/ui/src/app/pages/createConnector/connectorSteps/ConfigureConnectorTypeComponent.tsx
+++ b/ui/packages/ui/src/app/pages/createConnector/connectorSteps/ConfigureConnectorTypeComponent.tsx
@@ -1,5 +1,7 @@
 import { ConnectorProperty } from "@debezium/ui-models";
+import { Button } from '@patternfly/react-core';
 import * as React from 'react';
+import { PropertyCategory } from 'src/app/shared';
 import './ConfigureConnectorTypeComponent.css'
 import { ConfigureConnectorTypeForm } from './ConfigureConnectorTypeForm';
 
@@ -8,12 +10,24 @@ export interface IConfigureConnectorTypeComponentProps{
   basicPropertyValues: Map<string,string>;
   advancedPropertyDefinitions: ConnectorProperty[];
   advancedPropertyValues: Map<string,string>;
-  onValidateProperties: (connectorProperties: Map<string,string>) => void;
-  onSaveProperties: (connectorProperties: Map<string,string>) => void;
+  onValidateProperties: (connectorProperties: Map<string,string>, category: PropertyCategory) => void;
 }
 
 export const ConfigureConnectorTypeComponent: React.FC<IConfigureConnectorTypeComponentProps> = (props) => {
+
+  const handleValidation =() => {
+    // TODO: This is just an example.  The form will supply the property values
+    const basicValueMap = new Map<string,string>();
+    basicValueMap.set("database.name", "aName");
+    basicValueMap.set("database.user", "aUser");
+
+    props.onValidateProperties(basicValueMap, PropertyCategory.PROPS_BASIC);
+  }
+
   return (
-    <ConfigureConnectorTypeForm />
+    <>
+      <Button onClick={handleValidation}>Validate</Button>
+      <ConfigureConnectorTypeForm />
+    </>
   );
 }

--- a/ui/packages/ui/src/app/pages/createConnector/connectorSteps/FiltersStepComponent.tsx
+++ b/ui/packages/ui/src/app/pages/createConnector/connectorSteps/FiltersStepComponent.tsx
@@ -13,19 +13,28 @@ import {
 } from "@patternfly/react-core";
 import { SearchIcon } from "@patternfly/react-icons";
 import React from "react";
+import { PropertyCategory } from 'src/app/shared';
 import "./FiltersStepComponent.css";
 
 // tslint:disable-next-line: no-empty-interface
 export interface IFiltersStepComponentProps {
   propertyDefinitions: ConnectorProperty[];
   propertyValues: Map<string,string>;
-  onValidateProperties: (connectorProperties: Map<string,string>) => void;
-  onSaveProperties: (connectorProperties: Map<string,string>) => void;
+  onValidateProperties: (connectorProperties: Map<string,string>, category: PropertyCategory) => void;
 }
 
 export const FiltersStepComponent: React.FunctionComponent<IFiltersStepComponentProps> = (
   props
 ) => {
+
+  const handleValidation = () => {
+    // TODO: this is just an example.  Get the filter values from the form.
+    const filterValueMap = new Map<string,string>();
+    filterValueMap.set("schema.whitelist", "*");
+    filterValueMap.set("table.whitelist", "*");
+
+    props.onValidateProperties(filterValueMap, PropertyCategory.FILTERS);
+  }
 
   return (
     <>
@@ -37,6 +46,7 @@ export const FiltersStepComponent: React.FunctionComponent<IFiltersStepComponent
         comma-separated list of regular expresion that match the names of
         schema, table or column.
       </Text>
+      <Button onClick={handleValidation}>Validate</Button>
       <Flex className="filters-step-component_radioIcon">
         <FlexItem>
           <Radio

--- a/ui/packages/ui/src/app/shared/CategoryUtil.ts
+++ b/ui/packages/ui/src/app/shared/CategoryUtil.ts
@@ -1,0 +1,46 @@
+import { ConnectorProperty } from '@debezium/ui-models';
+
+export enum PropertyCategory {
+  PROPS_BASIC = "PROPS_BASIC",
+  PROPS_ADVANCED = "PROPS_ADVANCED",
+  FILTERS = "FILTERS",
+}
+
+export function getCategorizedPropertyDefinitions(propertyDefns: ConnectorProperty[]): ConnectorProperty[] {
+  const categorizedProps = [...propertyDefns];
+  for (const catProp of categorizedProps) {
+    if (
+      catProp.name === "database.server.name" ||
+      catProp.name === "database.dbname" ||
+      catProp.name === "database.hostname" ||
+      catProp.name === "database.port" ||
+      catProp.name === "database.user" ||
+      catProp.name === "database.password"
+    ) {
+      catProp.category = PropertyCategory.PROPS_BASIC;
+    } else if (
+      catProp.name === "database.tcpKeepAlive" ||
+      catProp.name === "database.initial.statements" ||
+      catProp.name === "plugin.name" ||
+      catProp.name === "publication.name" ||
+      catProp.name === "publication.autocreate.mode" ||
+      catProp.name === "slot.name" ||
+      catProp.name === "slot.drop.on.stop" ||
+      catProp.name === "slot.stream.params" ||
+      catProp.name === "slot.max.retries" ||
+      catProp.name === "slot.retry.delay.ms"
+    ) {
+      catProp.category = PropertyCategory.PROPS_ADVANCED;
+    } else if (
+      catProp.name === "schema.whitelist" ||
+      catProp.name === "schema.blacklist" ||
+      catProp.name === "table.whitelist" ||
+      catProp.name === "table.blacklist" ||
+      catProp.name === "column.whitelist" ||
+      catProp.name === "column.blacklist"
+    ) {
+      catProp.category = PropertyCategory.FILTERS;
+    }
+  }
+  return categorizedProps;
+}

--- a/ui/packages/ui/src/app/shared/Utils.ts
+++ b/ui/packages/ui/src/app/shared/Utils.ts
@@ -1,17 +1,11 @@
-import { ConnectorConfiguration, ConnectorType } from "@debezium/ui-models";
-import { ConnectorProperty } from '@debezium/ui-models';
+import { ConnectorProperty, ConnectorType } from "@debezium/ui-models";
+import { PropertyCategory } from '.';
 
 export enum ConnectorTypeId {
   POSTGRES = "postgres",
   MYSQL = "mysql",
   SQLSERVER = "sqlserver",
   MONGO = "mongodb",
-}
-
-export enum PropertyCategory {
-  PROPS_BASIC = "PROPS_BASIC",
-  PROPS_ADVANCED = "PROPS_ADVANCED",
-  FILTERS = "FILTERS",
 }
 
 /**
@@ -37,23 +31,6 @@ export function getConnectorTypeDescription(connType: ConnectorType): string {
 }
 
 /**
- * Get a new ConnectorConfiguration for the specified ConnectorType
- * @param connType the connector type
- */
-export function newConnectorConfiguration(connectorType: ConnectorType): ConnectorConfiguration {
-  let connectorConfig = null;
-  if (connectorType) {
-    connectorConfig = { 
-      "name": "tempName",
-      "config": {
-        "connector.class": connectorType.className
-      }
-    } as ConnectorConfiguration;
-  }
-  return connectorConfig;
-}
-
-/**
  * Get property definitions for the supplied category
  * @param propertyDefns the array of all ConnectorProperty objects
  * @param category the category for narrowing the ConnectorProperty objects
@@ -61,47 +38,15 @@ export function newConnectorConfiguration(connectorType: ConnectorType): Connect
 export function getPropertyDefinitions(propertyDefns: ConnectorProperty[], category: PropertyCategory): ConnectorProperty[] {
   const connProperties: ConnectorProperty[] = [];
   for (const propDefn of propertyDefns) {
-    if (isInCategory(propDefn, category)) {
+    if (propDefn.category === category) {
       connProperties.push(propDefn);
     }
   }
   return connProperties;
 }
 
-export function isInCategory(propertyDefn: ConnectorProperty, category: PropertyCategory) {
-  if (category === PropertyCategory.PROPS_BASIC && 
-    ( propertyDefn.name === 'database.server.name' ||
-      propertyDefn.name === 'database.dbname' ||
-      propertyDefn.name === 'database.hostname' ||
-      propertyDefn.name === 'database.port' ||
-      propertyDefn.name === 'database.user' ||
-      propertyDefn.name === 'database.password')
-    ) {
-    return true;
-  } else if (category === PropertyCategory.PROPS_ADVANCED && 
-    ( propertyDefn.name === 'database.tcpKeepAlive' ||
-      propertyDefn.name === 'database.initial.statements' ||
-      propertyDefn.name === 'plugin.name' ||
-      propertyDefn.name === 'publication.name' ||
-      propertyDefn.name === 'publication.autocreate.mode' ||
-      propertyDefn.name === 'slot.name' ||
-      propertyDefn.name === 'slot.drop.on.stop' ||
-      propertyDefn.name === 'slot.stream.params' ||
-      propertyDefn.name === 'slot.max.retries' ||
-      propertyDefn.name === 'slot.retry.delay.ms')
-    ) {
-    return true;
-  } else if (category === PropertyCategory.FILTERS &&
-    ( propertyDefn.name === 'schema.whitelist' ||
-      propertyDefn.name === 'schema.blacklist' ||
-      propertyDefn.name === 'table.whitelist' ||
-      propertyDefn.name === 'table.blacklist' ||
-      propertyDefn.name === 'column.whitelist' ||
-      propertyDefn.name === 'column.blacklist')
-    ) {
-    return true;
-  }
-  return false;
+export function mapToObject(inputMap: Map<string,string>) {
+  const obj = {}; inputMap.forEach((value, key) =>{ obj[key] = value; }); return obj;
 }
 
 /**

--- a/ui/packages/ui/src/app/shared/index.ts
+++ b/ui/packages/ui/src/app/shared/index.ts
@@ -1,4 +1,5 @@
 export * from './Utils';
+export * from './CategoryUtil';
 export * from './WithErrorBoundary';
 export * from './ApiError';
 export * from './ConfirmationDialog';


### PR DESCRIPTION
Made some adjustments to categorizing properties, and also made some changes to maintaining of the property values.  Did preliminary wiring of validation/save from the components.
- The assignment of property category was moved into CategoryUtil.  The optional category attribute is set on ConnectorProperty based on the property name.  Hopefully we can just remove this if the backend service can do the categorization.
- In CreateConnectorPage, now maintaining a map of the property values for each category separately.  These are then supplied to the appropriate wizard component for init of its forms.  Seemed easier to maintain this way, then upon finish merge the category maps to create the ConnectorConfiguration for submittal to the createConnector service.
- Removed the 'onSaveProperties' from the components for now.  We'll need to iron this out as UX design proceeds.
- Add temporary 'Validate' buttons in the FiltersStepComponent and ConfigureConnectorTypeComponent.  The validate actions send a couple properties to CreateConnectorPage which calls backend validate.  Temporarily added an alert there to show the validation result.
- An alert was also added upon click 'Finish', just to show the ConnectorConfig that would be submitted to the backend service.