### PR TITLE
Adding Runtime options step to wizard

### DIFF
--- a/ui/packages/models/src/ui.model.ts
+++ b/ui/packages/models/src/ui.model.ts
@@ -72,11 +72,12 @@ export interface ConnectorProperty {
     'ADVANCED_GENERAL' | 
     'ADVANCED_REPLICATION' | 
     'ADVANCED_PUBLICATION' | 
+    'ADVANCED_SSL' | 
     'FILTERS' |
-    'OPTIONS_TYPE_HANDLING' | 
-    'OPTIONS_COLUMNS' | 
-    'OPTIONS_SNAPSHOT' | 
-    'RUNTIME'
+    'DATA_OPTIONS_TYPE_HANDLING' | 
+    'DATA_OPTIONS_SNAPSHOT' | 
+    'RUNTIME_OPTIONS_ENGINE' | 
+    'RUNTIME_OPTIONS_HEARTBEAT'
     ;
     description: string;
     displayName: string;

--- a/ui/packages/ui/src/app/pages/createConnector/CreateConnectorPage.tsx
+++ b/ui/packages/ui/src/app/pages/createConnector/CreateConnectorPage.tsx
@@ -24,8 +24,9 @@ import {
   getAdvancedPropertyDefinitions,
   getBasicPropertyDefinitions,
   getCategorizedPropertyDefinitions,
+  getDataOptionsPropertyDefinitions,
   getFilterPropertyDefinitions,
-  getOptionsPropertyDefinitions,
+  getRuntimeOptionsPropertyDefinitions,
   mapToObject,
   PropertyCategory,
 } from "src/app/shared";
@@ -34,6 +35,7 @@ import {
   ConnectorTypeStepComponent,
   DataOptionsComponent,
   FiltersStepComponent,
+  RuntimeOptionsComponent
 } from "./connectorSteps";
 import "./CreateConnectorPage.css";
 
@@ -151,8 +153,8 @@ export const CreateConnectorPage: React.FunctionComponent = () => {
     if (
       category === PropertyCategory.ADVANCED_GENERAL ||
       category === PropertyCategory.ADVANCED_PUBLICATION ||
-      category === PropertyCategory.ADVANCED_REPLICATION
-    ) {
+      category === PropertyCategory.ADVANCED_REPLICATION ||
+      category === PropertyCategory.ADVANCED_SSL ) {
       setAdvancedPropValues(propertyValues);
     } else if (category === PropertyCategory.BASIC) {
       setBasicPropValues(propertyValues);
@@ -164,7 +166,8 @@ export const CreateConnectorPage: React.FunctionComponent = () => {
       category === PropertyCategory.BASIC ||
       category === PropertyCategory.ADVANCED_GENERAL ||
       category === PropertyCategory.ADVANCED_PUBLICATION ||
-      category === PropertyCategory.ADVANCED_REPLICATION
+      category === PropertyCategory.ADVANCED_REPLICATION ||
+      category === PropertyCategory.ADVANCED_SSL
     ) {
       connectorService
         .validateConnection("postgres", propertyValues)
@@ -282,9 +285,7 @@ export const CreateConnectorPage: React.FunctionComponent = () => {
       name: "Data Options",
       component: (
         <DataOptionsComponent
-          propertyDefinitions={getOptionsPropertyDefinitions(
-            selectedConnectorPropertyDefns
-          )}
+          propertyDefinitions={getDataOptionsPropertyDefinitions(selectedConnectorPropertyDefns)}
           propertyValues={optionsPropValues}
           onValidateProperties={handleValidateProperties}
         />
@@ -293,8 +294,14 @@ export const CreateConnectorPage: React.FunctionComponent = () => {
     },
     {
       id: 5,
-      name: "Set Target",
-      component: <p>component for set target</p>,
+      name: "Runtime Options",
+      component: (
+        <RuntimeOptionsComponent
+          propertyDefinitions={getRuntimeOptionsPropertyDefinitions(selectedConnectorPropertyDefns)}
+          propertyValues={optionsPropValues}
+          onValidateProperties={handleValidateProperties}
+        />
+      ),
       canJumpTo: stepIdReached >= 5,
       nextButtonText: "Finish",
     },

--- a/ui/packages/ui/src/app/pages/createConnector/connectorSteps/ConfigureConnectorTypeForm.tsx
+++ b/ui/packages/ui/src/app/pages/createConnector/connectorSteps/ConfigureConnectorTypeForm.tsx
@@ -143,10 +143,10 @@ export const ConfigureConnectorTypeForm: React.FunctionComponent<IConfigureConne
                   id="advanced"
                   className="dbz-c-accordion"
                 >
-                  Advance Properties
+                  Advanced Properties
                 </AccordionToggle>
                 <AccordionContent
-                  id="advance"
+                  id="advanced"
                   isHidden={!expanded.includes("advanced")}
                 >
                   <Grid hasGutter={true}>

--- a/ui/packages/ui/src/app/pages/createConnector/connectorSteps/index.ts
+++ b/ui/packages/ui/src/app/pages/createConnector/connectorSteps/index.ts
@@ -2,3 +2,4 @@ export * from './ConnectorTypeStepComponent';
 export * from './FiltersStepComponent';
 export * from './ConfigureConnectorTypeComponent'
 export * from './dataOptions'
+export * from './runtimeOptions'

--- a/ui/packages/ui/src/app/pages/createConnector/connectorSteps/runtimeOptions/RuntimeOptionsComponent.css
+++ b/ui/packages/ui/src/app/pages/createConnector/connectorSteps/runtimeOptions/RuntimeOptionsComponent.css
@@ -1,0 +1,5 @@
+.c-runtime-options{
+  &__spacer{
+    margin: 20px 0
+  }
+}

--- a/ui/packages/ui/src/app/pages/createConnector/connectorSteps/runtimeOptions/RuntimeOptionsComponent.tsx
+++ b/ui/packages/ui/src/app/pages/createConnector/connectorSteps/runtimeOptions/RuntimeOptionsComponent.tsx
@@ -1,0 +1,25 @@
+import { ConnectorProperty } from "@debezium/ui-models";
+import * as React from 'react';
+import { PropertyCategory } from "src/app/shared";
+import './RuntimeOptionsComponent.css'
+import { RuntimeOptionsForm } from './RuntimeOptionsForm';
+
+export interface IRuntimeOptionsComponentProps {
+  propertyDefinitions: ConnectorProperty[];
+  propertyValues: Map<string, string>;
+  onValidateProperties: (
+    connectorProperties: Map<string, string>,
+    category: PropertyCategory
+  ) => void;
+}
+
+export const RuntimeOptionsComponent: React.FC<IRuntimeOptionsComponentProps> = (props) => {
+ 
+  return (
+    <RuntimeOptionsForm 
+      propertyDefinitions={props.propertyDefinitions}
+      propertyValues={props.propertyValues}
+      onValidateProperties={props.onValidateProperties}
+    />
+  );
+}

--- a/ui/packages/ui/src/app/pages/createConnector/connectorSteps/runtimeOptions/RuntimeOptionsForm.tsx
+++ b/ui/packages/ui/src/app/pages/createConnector/connectorSteps/runtimeOptions/RuntimeOptionsForm.tsx
@@ -1,0 +1,156 @@
+import { ConnectorProperty } from '@debezium/ui-models/dist/js/ui.model';
+import {
+  Button,
+  Grid,
+  GridItem,
+  Title
+} from '@patternfly/react-core';
+import { Form, Formik } from 'formik';
+import _ from 'lodash';
+import * as React from 'react';
+import { PropertyCategory } from 'src/app/shared';
+import * as Yup from 'yup';
+import { FormInputComponent, FormSwitchComponent } from '../shared';
+
+export interface IRuntimeOptionsFormProps {
+  propertyDefinitions: ConnectorProperty[];
+  propertyValues: Map<string,string>;
+  onValidateProperties: (connectorProperties: Map<string,string>, category: PropertyCategory) => void;
+}
+
+export const RuntimeOptionsForm: React.FunctionComponent<IRuntimeOptionsFormProps> = (props) => {
+  const basicValidationSchema = {};
+
+  const formatPropertyDefinitions = (propertyValues: ConnectorProperty[]) => {
+    const orderedPropertyDefinitions = propertyValues.sort((a, b) => (
+      {orderInCategory: Number.MAX_VALUE, ...a}.orderInCategory -
+      {orderInCategory: Number.MAX_VALUE, ...b}.orderInCategory));
+
+    return orderedPropertyDefinitions.map((key: { name: string }) => {
+      key.name = key.name.replace(/\./g, '_');
+      return key;
+    })
+  }
+  const enginePropertyDefinitions = formatPropertyDefinitions(props.propertyDefinitions.filter(defn => defn.category === PropertyCategory.RUNTIME_OPTIONS_ENGINE));
+  const heartbeatPropertyDefinitions = formatPropertyDefinitions(props.propertyDefinitions.filter(defn => defn.category === PropertyCategory.RUNTIME_OPTIONS_HEARTBEAT));
+
+  // Just added String and Password type
+  enginePropertyDefinitions.map((key: any) => {
+    if (key.type === "STRING") {
+      basicValidationSchema[key.name] = Yup.string();
+    } else if (key.type === "PASSWORD") {
+      basicValidationSchema[key.name] = Yup.string();
+    } else if (key.type === "INT") {
+      basicValidationSchema[key.name] = Yup.string();
+    }
+    if (key.required) {
+      basicValidationSchema[key.name] = basicValidationSchema[key.name].required(`${key.name} is required`);
+    }
+  })
+
+  const validationSchema = Yup.object().shape({ ...basicValidationSchema });
+  
+  const getInitialValues = (combined: any) => {
+    const combinedValue: any = {};
+    
+    combined.map((key: { name: string; defaultValue: string}) => {
+      if (!combinedValue[key.name]) {
+        combinedValue[key.name] = key.defaultValue || "";
+      }
+    })
+    return combinedValue;
+  }
+
+  const initialValues = getInitialValues(_.union(enginePropertyDefinitions, heartbeatPropertyDefinitions));
+ 
+  return (
+    <div>
+      <Formik
+        initialValues={initialValues}
+        validationSchema={validationSchema}
+        onSubmit={(values) => {
+          let basicValueMap = new Map<string, string>();
+          basicValueMap = _.transform(
+            values,
+            (result, val: string, key: string) => {
+              result[key.replace(/_/g, ".")] = val;
+            }
+          );
+
+          props.onValidateProperties(
+            basicValueMap,
+            PropertyCategory.RUNTIME_OPTIONS_ENGINE
+          );
+        }}
+      >
+        {({ errors, touched, handleChange, isSubmitting }) => (
+          <Form className="pf-c-form">
+            <Title headingLevel="h2">Engine properties</Title>
+            <Grid hasGutter={true}>
+              {enginePropertyDefinitions.map(
+                (propertyDefinition: ConnectorProperty, index) => {
+                  return (
+                    <GridItem key={index}>
+                      <FormInputComponent
+                        isRequired={propertyDefinition.required}
+                        label={propertyDefinition.displayName}
+                        fieldId={propertyDefinition.name}
+                        name={propertyDefinition.name}
+                        type={propertyDefinition.type}
+                        helperTextInvalid={errors[propertyDefinition.name]}
+                        infoTitle={propertyDefinition.displayName}
+                        infoText={propertyDefinition.description}
+                        validated={
+                          errors[propertyDefinition.name] &&
+                          touched[propertyDefinition.name]
+                            ? "error"
+                            : "default"
+                        }
+                      />
+                    </GridItem>
+                  );
+                }
+              )}
+            </Grid>
+            <Title headingLevel="h2">Heartbeat properties</Title>
+            <Grid hasGutter={true}>
+              {heartbeatPropertyDefinitions.map(
+                (propertyDefinition: ConnectorProperty, index) => {
+                  if (propertyDefinition.type === "BOOLEAN") {
+                    return (
+                      <GridItem key={index}>
+                        <FormSwitchComponent
+                          label={propertyDefinition.displayName}
+                        />
+                      </GridItem>
+                    );
+                  } else {
+                    return (
+                      <GridItem key={index}>
+                        <FormInputComponent
+                          label={propertyDefinition.displayName}
+                          fieldId={propertyDefinition.name}
+                          name={propertyDefinition.name}
+                          type={propertyDefinition.type}
+                          infoTitle={propertyDefinition.displayName}
+                          infoText={propertyDefinition.description}
+                        />
+                      </GridItem>
+                    );
+                  }
+                }
+              )}
+            </Grid>
+            <Grid hasGutter={true}>
+              <GridItem>
+                <Button variant="primary" type="submit" disabled={isSubmitting}>
+                  Validate
+                </Button>
+              </GridItem>
+            </Grid>
+          </Form>
+        )}
+      </Formik>
+    </div>
+  );
+};

--- a/ui/packages/ui/src/app/pages/createConnector/connectorSteps/runtimeOptions/index.tsx
+++ b/ui/packages/ui/src/app/pages/createConnector/connectorSteps/runtimeOptions/index.tsx
@@ -1,0 +1,1 @@
+export * from './RuntimeOptionsComponent'

--- a/ui/packages/ui/src/app/shared/CategoryUtil.ts
+++ b/ui/packages/ui/src/app/shared/CategoryUtil.ts
@@ -35,6 +35,9 @@ export enum PropertyName {
   COLUMN_TRUNCATE_PREFIX = "column.truncate.to",
   INCLUDE_UNKNOWN_DATATYPES = "include.unknown.datatypes",
   TOASTED_VALUE_PLACEHOLDER = "toasted.value.placeholder",
+  PROVIDE_TRANSACTION_METADATA = "provide.transaction.metadata",
+  SCHEMA_REFRESH_MODE = "schema.refresh.mode",
+  SANITIZE_FIELD_NAMES = "sanitize.field.names",
   SNAPSHOT_MODE = "snapshot.mode",
   SNAPSHOT_DELAY_MS = "snapshot.delay.ms",
   SNAPSHOT_FETCH_SIZE = "snapshot.fetch.size",
@@ -47,7 +50,13 @@ export enum PropertyName {
   POLL_INTERVAL_MS = "poll.interval.ms",
   HEARTBEAT_INTERVAL_MS = "heartbeat.interval.ms",
   HEARTBEAT_TOPICS_PREFIX = "heartbeat.topics.prefix",
-  HEARTBEAT_ACTION_QUERY = "heartbeat.action.query"
+  HEARTBEAT_ACTION_QUERY = "heartbeat.action.query",
+  DATABASE_SSLMODE = "database.sslmode",
+  DATABASE_SSLCERT = "database.sslcert",
+  DATABASE_SSLPASSWORD = "database.sslpassword",
+  DATABASE_SSLROOTCERT = "database.sslrootcert",
+  DATABASE_SSLKEY = "database.sslkey",
+  DATABASE_SSLFACTORY = "database.sslfactory"
 }
 
 export enum PropertyCategory {
@@ -55,11 +64,12 @@ export enum PropertyCategory {
   ADVANCED_GENERAL = "ADVANCED_GENERAL",
   ADVANCED_REPLICATION = "ADVANCED_REPLICATION",
   ADVANCED_PUBLICATION = "ADVANCED_PUBLICATION",
+  ADVANCED_SSL = "ADVANCED_SSL",
   FILTERS = "FILTERS",
-  OPTIONS_TYPE_HANDLING = "OPTIONS_TYPE_HANDLING",
-  OPTIONS_COLUMNS = "OPTIONS_COLUMNS",
-  OPTIONS_SNAPSHOT = "OPTIONS_SNAPSHOT",
-  RUNTIME = "RUNTIME"
+  DATA_OPTIONS_TYPE_MAPPING = "DATA_OPTIONS_TYPE_MAPPING",
+  DATA_OPTIONS_SNAPSHOT = "DATA_OPTIONS_SNAPSHOT",
+  RUNTIME_OPTIONS_ENGINE = "RUNTIME_OPTIONS_ENGINE",
+  RUNTIME_OPTIONS_HEARTBEAT = "RUNTIME_OPTIONS_HEARTBEAT"
 }
 
 export function getCategorizedPropertyDefinitions(propertyDefns: ConnectorProperty[]): ConnectorProperty[] {
@@ -86,13 +96,13 @@ export function getCategorizedPropertyDefinitions(propertyDefns: ConnectorProper
       catProp.category = PropertyCategory.ADVANCED_GENERAL;
     // ADVANCED PUBLICATION PROPS
     } else if (
-      catProp.name === PropertyName.PLUGIN_NAME ||
       catProp.name === PropertyName.PUBLICATION_NAME ||
       catProp.name === PropertyName.PUBLICATION_AUTOCREATE_MODE
     ) {
       catProp.category = PropertyCategory.ADVANCED_PUBLICATION;
     // ADVANCED REPLICATION PROPS
     } else if (
+      catProp.name === PropertyName.PLUGIN_NAME ||
       catProp.name === PropertyName.SLOT_NAME ||
       catProp.name === PropertyName.SLOT_DROP_ON_STOP ||
       catProp.name === PropertyName.SLOT_STREAM_PARAMS ||
@@ -100,6 +110,16 @@ export function getCategorizedPropertyDefinitions(propertyDefns: ConnectorProper
       catProp.name === PropertyName.SLOT_RETRY_DELAY_MS
     ) {
       catProp.category = PropertyCategory.ADVANCED_REPLICATION;
+    // ADVANCED SSL
+    } else if (
+      catProp.name === PropertyName.DATABASE_SSLMODE ||
+      catProp.name === PropertyName.DATABASE_SSLCERT ||
+      catProp.name === PropertyName.DATABASE_SSLPASSWORD ||
+      catProp.name === PropertyName.DATABASE_SSLROOTCERT ||
+      catProp.name === PropertyName.DATABASE_SSLKEY ||
+      catProp.name === PropertyName.DATABASE_SSLFACTORY
+    ) {
+      catProp.category = PropertyCategory.ADVANCED_SSL;
     // FILTER PROPS
     } else if (
       catProp.name === PropertyName.SCHEMA_WHITELIST ||
@@ -110,27 +130,26 @@ export function getCategorizedPropertyDefinitions(propertyDefns: ConnectorProper
       catProp.name === PropertyName.COLUMN_BLACKLIST
     ) {
       catProp.category = PropertyCategory.FILTERS;
-    // OPTIONS TYPE_HANDLING PROPS
+    // DATA OPTIONS TYPE MAPPING PROPS
     } else if (
       catProp.name === PropertyName.DECIMAL_HANDLING_MODE ||
       catProp.name === PropertyName.HSTORE_HANDLING_MODE ||
       catProp.name === PropertyName.BINARY_HANDLING_MODE ||
       catProp.name === PropertyName.INTERVAL_HANDLING_MODE ||
       catProp.name === PropertyName.TIME_PRECISION_MODE ||
-      catProp.name === PropertyName.TOMBSTONES_ON_DELETE
-    ) {
-      catProp.category = PropertyCategory.OPTIONS_TYPE_HANDLING;
-    // OPTIONS COLUMNS PROPS
-    } else if (
+      catProp.name === PropertyName.TOMBSTONES_ON_DELETE ||
       catProp.name === PropertyName.MESSAGE_KEY_COLUMNS ||
       catProp.name.startsWith(PropertyName.COLUMN_MASK_HASH_PREFIX) ||
       catProp.name.startsWith(PropertyName.COLUMN_MASK_WITH_PREFIX) ||
       catProp.name.startsWith(PropertyName.COLUMN_TRUNCATE_PREFIX) ||
       catProp.name === PropertyName.INCLUDE_UNKNOWN_DATATYPES ||
-      catProp.name === PropertyName.TOASTED_VALUE_PLACEHOLDER
+      catProp.name === PropertyName.TOASTED_VALUE_PLACEHOLDER ||
+      catProp.name === PropertyName.PROVIDE_TRANSACTION_METADATA ||
+      catProp.name === PropertyName.SCHEMA_REFRESH_MODE ||
+      catProp.name === PropertyName.SANITIZE_FIELD_NAMES
     ) {
-      catProp.category = PropertyCategory.OPTIONS_COLUMNS;
-    // OPTIONS SNAPSHOT PROPS
+      catProp.category = PropertyCategory.DATA_OPTIONS_TYPE_MAPPING;
+    // DATA OPTIONS SNAPSHOT PROPS
     } else if (
       catProp.name === PropertyName.SNAPSHOT_MODE ||
       catProp.name === PropertyName.SNAPSHOT_DELAY_MS ||
@@ -139,18 +158,21 @@ export function getCategorizedPropertyDefinitions(propertyDefns: ConnectorProper
       catProp.name === PropertyName.SNAPSHOT_LOCK_TIMEOUT_MS ||
       catProp.name === PropertyName.SNAPSHOT_CUSTOM_CLASS
     ) {
-      catProp.category = PropertyCategory.OPTIONS_SNAPSHOT;
-    // RUNTIME
+      catProp.category = PropertyCategory.DATA_OPTIONS_SNAPSHOT;
+    // RUNTIME ENGINE PROPS
     } else if (
-      catProp.name === PropertyName.EVENT_PROCESSING_FAILURE_HANDLING_MODE ||
-      catProp.name === PropertyName.MAX_BATCH_SIZE ||
-      catProp.name === PropertyName.MAX_QUEUE_SIZE ||
-      catProp.name === PropertyName.POLL_INTERVAL_MS ||
       catProp.name === PropertyName.HEARTBEAT_INTERVAL_MS ||
       catProp.name === PropertyName.HEARTBEAT_TOPICS_PREFIX ||
       catProp.name === PropertyName.HEARTBEAT_ACTION_QUERY
     ) {
-      catProp.category = PropertyCategory.RUNTIME;
+      catProp.category = PropertyCategory.RUNTIME_OPTIONS_HEARTBEAT;
+    } else if (
+      catProp.name === PropertyName.EVENT_PROCESSING_FAILURE_HANDLING_MODE ||
+      catProp.name === PropertyName.MAX_BATCH_SIZE ||
+      catProp.name === PropertyName.MAX_QUEUE_SIZE ||
+      catProp.name === PropertyName.POLL_INTERVAL_MS
+    ) {
+      catProp.category = PropertyCategory.RUNTIME_OPTIONS_ENGINE;
     }
   }
 
@@ -243,19 +265,7 @@ export function getCategorizedPropertyDefinitions(propertyDefns: ConnectorProper
       } else if ( orderedProp.name === PropertyName.COLUMN_BLACKLIST ) {
         orderedProp.orderInCategory = 6;
       }
-    } else if ( orderedProp.category === PropertyCategory.OPTIONS_COLUMNS ) {
-      if ( orderedProp.name.startsWith(PropertyName.COLUMN_TRUNCATE_PREFIX) ) {
-        orderedProp.orderInCategory = 1;
-      } else if ( orderedProp.name.startsWith(PropertyName.COLUMN_MASK_HASH_PREFIX) ) {
-        orderedProp.orderInCategory = 2;
-      } else if ( orderedProp.name.startsWith(PropertyName.COLUMN_MASK_WITH_PREFIX) ) {
-        orderedProp.orderInCategory = 3;
-      } else if ( orderedProp.name === PropertyName.MESSAGE_KEY_COLUMNS ) {
-        orderedProp.orderInCategory = 4;
-      } else if ( orderedProp.name === PropertyName.INCLUDE_UNKNOWN_DATATYPES ) {
-        orderedProp.orderInCategory = 5;
-      }
-    } else if ( orderedProp.category === PropertyCategory.OPTIONS_TYPE_HANDLING ) {
+    } else if ( orderedProp.category === PropertyCategory.DATA_OPTIONS_TYPE_MAPPING ) {
       if ( orderedProp.name === PropertyName.TIME_PRECISION_MODE ) {
         orderedProp.orderInCategory = 1;
       } else if ( orderedProp.name === PropertyName.BINARY_HANDLING_MODE ) {
@@ -266,8 +276,28 @@ export function getCategorizedPropertyDefinitions(propertyDefns: ConnectorProper
         orderedProp.orderInCategory = 4;
       } else if ( orderedProp.name === PropertyName.HSTORE_HANDLING_MODE ) {
         orderedProp.orderInCategory = 5;
+      } else if( orderedProp.name.startsWith(PropertyName.TOMBSTONES_ON_DELETE) ) {
+        orderedProp.orderInCategory = 6;
+      } else if( orderedProp.name.startsWith(PropertyName.MESSAGE_KEY_COLUMNS) ) {
+        orderedProp.orderInCategory = 7;
+      } else if( orderedProp.name.startsWith(PropertyName.COLUMN_TRUNCATE_PREFIX) ) {
+        orderedProp.orderInCategory = 8;
+      } else if ( orderedProp.name.startsWith(PropertyName.COLUMN_MASK_HASH_PREFIX) ) {
+        orderedProp.orderInCategory = 9;
+      } else if ( orderedProp.name.startsWith(PropertyName.COLUMN_MASK_WITH_PREFIX) ) {
+        orderedProp.orderInCategory = 10;
+      } else if ( orderedProp.name === PropertyName.INCLUDE_UNKNOWN_DATATYPES ) {
+        orderedProp.orderInCategory = 11;
+      } else if ( orderedProp.name === PropertyName.TOASTED_VALUE_PLACEHOLDER ) {
+        orderedProp.orderInCategory = 12;
+      } else if ( orderedProp.name === PropertyName.PROVIDE_TRANSACTION_METADATA ) {
+        orderedProp.orderInCategory = 13;
+      } else if ( orderedProp.name === PropertyName.SCHEMA_REFRESH_MODE ) {
+        orderedProp.orderInCategory = 14;
+      } else if ( orderedProp.name === PropertyName.SANITIZE_FIELD_NAMES ) {
+        orderedProp.orderInCategory = 15;
       }
-    } else if ( orderedProp.category === PropertyCategory.OPTIONS_SNAPSHOT ) {
+    } else if ( orderedProp.category === PropertyCategory.DATA_OPTIONS_SNAPSHOT ) {
       if ( orderedProp.name === PropertyName.SNAPSHOT_MODE ) {
         orderedProp.orderInCategory = 1;
       } else if ( orderedProp.name === PropertyName.SNAPSHOT_CUSTOM_CLASS ) {
@@ -281,7 +311,7 @@ export function getCategorizedPropertyDefinitions(propertyDefns: ConnectorProper
       } else if ( orderedProp.name === PropertyName.SNAPSHOT_FETCH_SIZE ) {
         orderedProp.orderInCategory = 6;
       }
-    } else if ( orderedProp.category === PropertyCategory.RUNTIME ) {
+    } else if ( orderedProp.category === PropertyCategory.RUNTIME_OPTIONS_ENGINE ) {
       if ( orderedProp.name === PropertyName.EVENT_PROCESSING_FAILURE_HANDLING_MODE ) {
         orderedProp.orderInCategory = 1;
       } else if ( orderedProp.name === PropertyName.MAX_QUEUE_SIZE ) {
@@ -290,12 +320,14 @@ export function getCategorizedPropertyDefinitions(propertyDefns: ConnectorProper
         orderedProp.orderInCategory = 3;
       } else if ( orderedProp.name === PropertyName.POLL_INTERVAL_MS ) {
         orderedProp.orderInCategory = 4;
-      } else if ( orderedProp.name === PropertyName.HEARTBEAT_INTERVAL_MS ) {
-        orderedProp.orderInCategory = 5;
+      } 
+    } else if ( orderedProp.category === PropertyCategory.RUNTIME_OPTIONS_HEARTBEAT ) {
+      if ( orderedProp.name === PropertyName.HEARTBEAT_INTERVAL_MS ) {
+        orderedProp.orderInCategory = 1;
       } else if ( orderedProp.name === PropertyName.HEARTBEAT_TOPICS_PREFIX ) {
-        orderedProp.orderInCategory = 6;
+        orderedProp.orderInCategory = 2;
       } else if ( orderedProp.name === PropertyName.HEARTBEAT_ACTION_QUERY ) {
-        orderedProp.orderInCategory = 7;
+        orderedProp.orderInCategory = 3;
       }
     }
   }

--- a/ui/packages/ui/src/app/shared/Utils.ts
+++ b/ui/packages/ui/src/app/shared/Utils.ts
@@ -83,18 +83,17 @@ export function getFilterPropertyDefinitions(
 }
 
 /**
- * Get the options properties
+ * Get the data options properties
  * @param propertyDefns the array of all ConnectorProperty objects
  */
-export function getOptionsPropertyDefinitions(
+export function getDataOptionsPropertyDefinitions(
   propertyDefns: ConnectorProperty[]
 ): ConnectorProperty[] {
   const connProperties: ConnectorProperty[] = [];
   for (const propDefn of propertyDefns) {
     if (
-      propDefn.category === PropertyCategory.OPTIONS_TYPE_HANDLING ||
-      propDefn.category === PropertyCategory.OPTIONS_COLUMNS ||
-      propDefn.category === PropertyCategory.OPTIONS_SNAPSHOT
+      propDefn.category === PropertyCategory.DATA_OPTIONS_TYPE_MAPPING ||
+      propDefn.category === PropertyCategory.DATA_OPTIONS_SNAPSHOT
     ) {
       connProperties.push(propDefn);
     }
@@ -103,15 +102,18 @@ export function getOptionsPropertyDefinitions(
 }
 
 /**
- * Get the runtime properties
+ * Get the runtime options properties
  * @param propertyDefns the array of all ConnectorProperty objects
  */
-export function getRuntimePropertyDefinitons(
+export function getRuntimeOptionsPropertyDefinitions(
   propertyDefns: ConnectorProperty[]
 ): ConnectorProperty[] {
   const connProperties: ConnectorProperty[] = [];
   for (const propDefn of propertyDefns) {
-    if (propDefn.category === PropertyCategory.RUNTIME) {
+    if (
+      propDefn.category === PropertyCategory.RUNTIME_OPTIONS_ENGINE ||
+      propDefn.category === PropertyCategory.RUNTIME_OPTIONS_HEARTBEAT
+    ) {
       connProperties.push(propDefn);
     }
   }


### PR DESCRIPTION
Added a component for the final wizard step - Runtime Options.  The properties are grouped into 'Engine properties' and 'Heartbeat properties' per the current mockup.
- Reworked the categories for Data Options and Runtime Options to better match the design doc.
- added SSL properties and a few other missing properties.  SSL will not be displayed initially - it's just there for completeness
- Added the RuntimeOptionsComponent and RuntimeOptionsForm.  Validation still needs to be hooked up
Much of this will require more rework whenever the service is in place which provides additional property metadata (eg category, ordering, etc).