### PR TITLE
Refining properties and adapting to service

### DIFF
--- a/ui/packages/models/src/ui.model.ts
+++ b/ui/packages/models/src/ui.model.ts
@@ -68,22 +68,24 @@ export interface ConnectionValidationResult {
  */
 // tslint:disable-next-line: interface-name
 export interface ConnectorProperty {
-    category?: 'BASIC' | 
-    'ADVANCED_GENERAL' | 
-    'ADVANCED_REPLICATION' | 
-    'ADVANCED_PUBLICATION' | 
-    'ADVANCED_SSL' | 
+    allowedValues: string[];
+    category: 'CONNECTION' | 
+    'CONNECTION_ADVANCED' | 
+    'CONNECTION_ADVANCED_REPLICATION' | 
+    'CONNECTION_ADVANCED_PUBLICATION' | 
+    'CONNECTION_ADVANCED_SSL' | 
     'FILTERS' |
-    'DATA_OPTIONS_TYPE_HANDLING' | 
-    'DATA_OPTIONS_SNAPSHOT' | 
-    'RUNTIME_OPTIONS_ENGINE' | 
-    'RUNTIME_OPTIONS_HEARTBEAT'
+    'CONNECTOR' |
+    'CONNECTOR_ADVANCED' | 
+    'CONNECTOR_SNAPSHOT' | 
+    'ADVANCED' | 
+    'ADVANCED_HEARTBEAT'
     ;
     description: string;
     displayName: string;
     name: string;
     orderInCategory?: number;
-    required?: boolean;
+    isMandatory: boolean;
     type: 'BOOLEAN' | 'STRING' | 'INT' | 'SHORT' | 'LONG' | 'DOUBLE' | 'LIST' | 'CLASS' | 'PASSWORD';
 }
 

--- a/ui/packages/ui/src/app/pages/createConnector/connectorSteps/ConfigureConnectorTypeForm.css
+++ b/ui/packages/ui/src/app/pages/createConnector/connectorSteps/ConfigureConnectorTypeForm.css
@@ -1,0 +1,6 @@
+.configure-connector-type-form {
+  &-grouping {
+    margin-top: 30px;
+    margin-bottom: 10px;
+  }
+}

--- a/ui/packages/ui/src/app/pages/createConnector/connectorSteps/dataOptions/DataOptionsForm.tsx
+++ b/ui/packages/ui/src/app/pages/createConnector/connectorSteps/dataOptions/DataOptionsForm.tsx
@@ -33,9 +33,9 @@ export const DataOptionsForm: React.FunctionComponent<IDataOptionsFormProps> = (
       return key;
     })
   }
-  const mappingPropertyDefinitions = formatPropertyDefinitions(props.propertyDefinitions.filter(defn => defn.category === PropertyCategory.DATA_OPTIONS_TYPE_MAPPING));
+  const mappingPropertyDefinitions = formatPropertyDefinitions(props.propertyDefinitions.filter(defn => defn.category === PropertyCategory.DATA_OPTIONS_GENERAL || defn.category === PropertyCategory.DATA_OPTIONS_ADVANCED));
   const snapshotPropertyDefinitions = formatPropertyDefinitions(props.propertyDefinitions.filter(defn => defn.category === PropertyCategory.DATA_OPTIONS_SNAPSHOT));
-  
+ 
   const toggle = (e: React.MouseEvent<HTMLButtonElement, MouseEvent>, id: string) => {
     e.preventDefault();
     const index = expanded.indexOf(id);
@@ -72,7 +72,7 @@ export const DataOptionsForm: React.FunctionComponent<IDataOptionsFormProps> = (
 
           props.onValidateProperties(
             basicValueMap,
-            PropertyCategory.DATA_OPTIONS_TYPE_MAPPING
+            PropertyCategory.DATA_OPTIONS_GENERAL
           );
         }}
       >

--- a/ui/packages/ui/src/app/pages/createConnector/connectorSteps/runtimeOptions/RuntimeOptionsForm.tsx
+++ b/ui/packages/ui/src/app/pages/createConnector/connectorSteps/runtimeOptions/RuntimeOptionsForm.tsx
@@ -43,7 +43,7 @@ export const RuntimeOptionsForm: React.FunctionComponent<IRuntimeOptionsFormProp
     } else if (key.type === "INT") {
       basicValidationSchema[key.name] = Yup.string();
     }
-    if (key.required) {
+    if (key.isMandatory) {
       basicValidationSchema[key.name] = basicValidationSchema[key.name].required(`${key.name} is required`);
     }
   })
@@ -92,7 +92,7 @@ export const RuntimeOptionsForm: React.FunctionComponent<IRuntimeOptionsFormProp
                   return (
                     <GridItem key={index}>
                       <FormInputComponent
-                        isRequired={propertyDefinition.required}
+                        isRequired={propertyDefinition.isMandatory}
                         label={propertyDefinition.displayName}
                         fieldId={propertyDefinition.name}
                         name={propertyDefinition.name}

--- a/ui/packages/ui/src/app/pages/createConnector/connectorSteps/shared/FormCheckboxComponent.tsx
+++ b/ui/packages/ui/src/app/pages/createConnector/connectorSteps/shared/FormCheckboxComponent.tsx
@@ -6,14 +6,16 @@ export interface IFormCheckboxComponentProps {
   label: string;
   name: string;
   isChecked: boolean
+  propertyChange: (name: string, selection: any) => void;
 }
 
 export const FormCheckboxComponent: React.FunctionComponent<IFormCheckboxComponentProps> = props => {
   const [checked, setChecked] = React.useState(true);
   const [field] = useField(props);
   
-  const handleChange = (v) => {
-    setChecked(v);
+  const handleChange = (value: boolean) => {
+    setChecked(value);
+    props.propertyChange(field.name, value);
   };
     return (
       <Checkbox

--- a/ui/packages/ui/src/app/pages/createConnector/connectorSteps/shared/FormComponent.tsx
+++ b/ui/packages/ui/src/app/pages/createConnector/connectorSteps/shared/FormComponent.tsx
@@ -1,0 +1,59 @@
+import { ConnectorProperty } from '@debezium/ui-models';
+import * as React from 'react';
+import { FormCheckboxComponent } from './FormCheckboxComponent';
+import { FormInputComponent } from './FormInputComponent';
+import { FormSelectComponent } from './FormSelectComponent';
+
+export interface IFormComponentProps {
+  propertyDefinition: ConnectorProperty;
+  helperTextInvalid?: any;
+  validated?: "default" | "success" | "warning" | "error" | undefined
+  propertyChange: (name: string, selection: any) => void;
+}
+
+export const FormComponent: React.FunctionComponent<IFormComponentProps> = (
+  props
+) => {
+  // Has allowed values - Select component
+  if (props.propertyDefinition.allowedValues) {
+    return (
+      <FormSelectComponent
+        fieldId={props.propertyDefinition.name}
+        helperTextInvalid={props.helperTextInvalid}
+        isRequired={props.propertyDefinition.isMandatory}
+        description={props.propertyDefinition.description}
+        label={props.propertyDefinition.displayName}
+        name={props.propertyDefinition.name}
+        propertyChange={props.propertyChange}
+        options={props.propertyDefinition.allowedValues}
+      />
+    );
+    // Boolean - checkbox
+  } else if (props.propertyDefinition.type === "BOOLEAN") {
+    return (
+      <FormCheckboxComponent
+        isChecked={props.propertyDefinition.defaultValue || false}
+        label={props.propertyDefinition.displayName}
+        name={props.propertyDefinition.name}
+        propertyChange={props.propertyChange}
+      />
+    );
+    // Any other - Text input
+  } else {
+    return (
+      <FormInputComponent
+        isRequired={props.propertyDefinition.isMandatory}
+        label={props.propertyDefinition.displayName}
+        fieldId={props.propertyDefinition.name}
+        name={props.propertyDefinition.name}
+        type={props.propertyDefinition.type}
+        helperTextInvalid={props.helperTextInvalid}
+        infoTitle={
+          props.propertyDefinition.displayName || props.propertyDefinition.name
+        }
+        infoText={props.propertyDefinition.description}
+        validated={props.validated}
+      />
+    );
+  }
+};

--- a/ui/packages/ui/src/app/pages/createConnector/connectorSteps/shared/FormSelectComponent.tsx
+++ b/ui/packages/ui/src/app/pages/createConnector/connectorSteps/shared/FormSelectComponent.tsx
@@ -21,7 +21,8 @@ export interface IFormSelectComponentProps {
     fieldId: string,
     helperTextInvalid: string,
     isRequired: boolean,
-    options: ISelectOptions[]
+    options: ISelectOptions[],
+    propertyChange: (name: string, selection: any) => void;
 }
 
 export const FormSelectComponent = (props: IFormSelectComponentProps) => {
@@ -31,30 +32,30 @@ export const FormSelectComponent = (props: IFormSelectComponentProps) => {
     fieldId,
     helperTextInvalid,
     options,
-    setFieldValue
+    propertyChange
   } = props;
   
   const [isOpen, setOpen] = React.useState<boolean>(false)
-  const [selected, setSelected] = React.useState<boolean>(null)
+  const [selected, setSelected] = React.useState<boolean>(false)
   const [field] = useField(props);
 
-  const onToggle = (open) => {
+  const onToggle = (open: boolean) => {
     setOpen(open)
   };
 
   const clearSelection = () => {
-    setSelected(null)
+    setSelected(false)
     setOpen(false)
   };  
 
-  const onSelect = (e, selection, isPlaceholder) => {
+  const onSelect = (e, selection: boolean, isPlaceholder: boolean) => {
     if (isPlaceholder) {
       clearSelection();
     }
     else {
       setSelected(selection)
       setOpen(false)
-      setFieldValue(field.name, selection);
+      propertyChange(field.name, selection);
     }
   };
 

--- a/ui/packages/ui/src/app/pages/createConnector/connectorSteps/shared/FormSwitchComponent.tsx
+++ b/ui/packages/ui/src/app/pages/createConnector/connectorSteps/shared/FormSwitchComponent.tsx
@@ -6,14 +6,16 @@ export interface IFormSwitchComponentProps {
   label: string;
   name: string;
   isChecked: boolean
+  propertyChange: (name: string, selection: any) => void;
 }
 
 export const FormSwitchComponent: React.FunctionComponent<IFormSwitchComponentProps> = props => {
   const [isSwitched, setSwitched] = React.useState(true);
   const [field] = useField(props);
   
-  const handleChange = (v) => {
-    setSwitched(v);
+  const handleChange = (value: boolean) => {
+    setSwitched(value);
+    props.propertyChange(field.name, value);
   };
     return (
       <Switch

--- a/ui/packages/ui/src/app/pages/createConnector/connectorSteps/shared/index.tsx
+++ b/ui/packages/ui/src/app/pages/createConnector/connectorSteps/shared/index.tsx
@@ -2,4 +2,5 @@ export * from './FormCheckboxComponent'
 export * from './FormInputComponent'
 export * from './FormSelectComponent'
 export * from './FormSwitchComponent'
+export * from './FormComponent'
 

--- a/ui/packages/ui/src/app/shared/CategoryUtil.ts
+++ b/ui/packages/ui/src/app/shared/CategoryUtil.ts
@@ -56,160 +56,34 @@ export enum PropertyName {
   DATABASE_SSLPASSWORD = "database.sslpassword",
   DATABASE_SSLROOTCERT = "database.sslrootcert",
   DATABASE_SSLKEY = "database.sslkey",
-  DATABASE_SSLFACTORY = "database.sslfactory"
+  DATABASE_SSLFACTORY = "database.sslfactory",
+  SKIPPED_OPERATIONS = "skipped.operations",
+  RETRIABLE_RESTART_CONNECTOR_WAIT_MS = "retriable.restart.connector.wait.ms",
+  SOURCE_STRUCT_VERSION = "source.struct.version",
+  STATUS_UPDATE_INTERVAL_MS = "status.update.interval.ms",
+  XMIN_FETCH_INTERVAL_MS = "xmin.fetch.interval.ms",
+  CONVERTERS = "converters"
 }
 
 export enum PropertyCategory {
-  BASIC = "BASIC",
-  ADVANCED_GENERAL = "ADVANCED_GENERAL",
-  ADVANCED_REPLICATION = "ADVANCED_REPLICATION",
-  ADVANCED_PUBLICATION = "ADVANCED_PUBLICATION",
-  ADVANCED_SSL = "ADVANCED_SSL",
+  BASIC = "CONNECTION",
+  ADVANCED_GENERAL = "CONNECTION_ADVANCED",
+  ADVANCED_REPLICATION = "CONNECTION_ADVANCED_REPLICATION",
+  ADVANCED_PUBLICATION = "CONNECTION_ADVANCED_PUBLICATION",
+  ADVANCED_SSL = "CONNECTION_ADVANCED_SSL",
   FILTERS = "FILTERS",
-  DATA_OPTIONS_TYPE_MAPPING = "DATA_OPTIONS_TYPE_MAPPING",
-  DATA_OPTIONS_SNAPSHOT = "DATA_OPTIONS_SNAPSHOT",
-  RUNTIME_OPTIONS_ENGINE = "RUNTIME_OPTIONS_ENGINE",
-  RUNTIME_OPTIONS_HEARTBEAT = "RUNTIME_OPTIONS_HEARTBEAT"
+  DATA_OPTIONS_GENERAL = "CONNECTOR",
+  DATA_OPTIONS_SNAPSHOT = "CONNECTOR_SNAPSHOT",
+  DATA_OPTIONS_ADVANCED = "CONNECTOR_ADVANCED",
+  RUNTIME_OPTIONS_ENGINE = "ADVANCED",
+  RUNTIME_OPTIONS_HEARTBEAT = "ADVANCED_HEARTBEAT"
 }
 
 export function getCategorizedPropertyDefinitions(propertyDefns: ConnectorProperty[]): ConnectorProperty[] {
-  const categorizedProps = [...propertyDefns];
-  // ------------------
-  // Set the categories
-  // ------------------
-  for (const catProp of categorizedProps) {
-    // BASIC PROPS
-    if (
-      catProp.name === PropertyName.DATABASE_SERVER_NAME ||
-      catProp.name === PropertyName.DATABASE_DBNAME ||
-      catProp.name === PropertyName.DATABASE_HOSTNAME ||
-      catProp.name === PropertyName.DATABASE_PORT ||
-      catProp.name === PropertyName.DATABASE_USER ||
-      catProp.name === PropertyName.DATABASE_PASSWORD
-    ) {
-      catProp.category = PropertyCategory.BASIC;
-    // ADVANCED GENERAL PROPS
-    } else if (
-      catProp.name === PropertyName.DATABASE_TCPKEEPALIVE ||
-      catProp.name === PropertyName.DATABASE_INITIAL_STATEMENTS
-    ) {
-      catProp.category = PropertyCategory.ADVANCED_GENERAL;
-    // ADVANCED PUBLICATION PROPS
-    } else if (
-      catProp.name === PropertyName.PUBLICATION_NAME ||
-      catProp.name === PropertyName.PUBLICATION_AUTOCREATE_MODE
-    ) {
-      catProp.category = PropertyCategory.ADVANCED_PUBLICATION;
-    // ADVANCED REPLICATION PROPS
-    } else if (
-      catProp.name === PropertyName.PLUGIN_NAME ||
-      catProp.name === PropertyName.SLOT_NAME ||
-      catProp.name === PropertyName.SLOT_DROP_ON_STOP ||
-      catProp.name === PropertyName.SLOT_STREAM_PARAMS ||
-      catProp.name === PropertyName.SLOT_MAX_RETRIES ||
-      catProp.name === PropertyName.SLOT_RETRY_DELAY_MS
-    ) {
-      catProp.category = PropertyCategory.ADVANCED_REPLICATION;
-    // ADVANCED SSL
-    } else if (
-      catProp.name === PropertyName.DATABASE_SSLMODE ||
-      catProp.name === PropertyName.DATABASE_SSLCERT ||
-      catProp.name === PropertyName.DATABASE_SSLPASSWORD ||
-      catProp.name === PropertyName.DATABASE_SSLROOTCERT ||
-      catProp.name === PropertyName.DATABASE_SSLKEY ||
-      catProp.name === PropertyName.DATABASE_SSLFACTORY
-    ) {
-      catProp.category = PropertyCategory.ADVANCED_SSL;
-    // FILTER PROPS
-    } else if (
-      catProp.name === PropertyName.SCHEMA_WHITELIST ||
-      catProp.name === PropertyName.SCHEMA_BLACKLIST ||
-      catProp.name === PropertyName.TABLE_WHITELIST ||
-      catProp.name === PropertyName.TABLE_BLACKLIST ||
-      catProp.name === PropertyName.COLUMN_WHITELIST ||
-      catProp.name === PropertyName.COLUMN_BLACKLIST
-    ) {
-      catProp.category = PropertyCategory.FILTERS;
-    // DATA OPTIONS TYPE MAPPING PROPS
-    } else if (
-      catProp.name === PropertyName.DECIMAL_HANDLING_MODE ||
-      catProp.name === PropertyName.HSTORE_HANDLING_MODE ||
-      catProp.name === PropertyName.BINARY_HANDLING_MODE ||
-      catProp.name === PropertyName.INTERVAL_HANDLING_MODE ||
-      catProp.name === PropertyName.TIME_PRECISION_MODE ||
-      catProp.name === PropertyName.TOMBSTONES_ON_DELETE ||
-      catProp.name === PropertyName.MESSAGE_KEY_COLUMNS ||
-      catProp.name.startsWith(PropertyName.COLUMN_MASK_HASH_PREFIX) ||
-      catProp.name.startsWith(PropertyName.COLUMN_MASK_WITH_PREFIX) ||
-      catProp.name.startsWith(PropertyName.COLUMN_TRUNCATE_PREFIX) ||
-      catProp.name === PropertyName.INCLUDE_UNKNOWN_DATATYPES ||
-      catProp.name === PropertyName.TOASTED_VALUE_PLACEHOLDER ||
-      catProp.name === PropertyName.PROVIDE_TRANSACTION_METADATA ||
-      catProp.name === PropertyName.SCHEMA_REFRESH_MODE ||
-      catProp.name === PropertyName.SANITIZE_FIELD_NAMES
-    ) {
-      catProp.category = PropertyCategory.DATA_OPTIONS_TYPE_MAPPING;
-    // DATA OPTIONS SNAPSHOT PROPS
-    } else if (
-      catProp.name === PropertyName.SNAPSHOT_MODE ||
-      catProp.name === PropertyName.SNAPSHOT_DELAY_MS ||
-      catProp.name === PropertyName.SNAPSHOT_FETCH_SIZE ||
-      catProp.name === PropertyName.SNAPSHOT_SELECT_STATEMENT_OVERRIDES ||
-      catProp.name === PropertyName.SNAPSHOT_LOCK_TIMEOUT_MS ||
-      catProp.name === PropertyName.SNAPSHOT_CUSTOM_CLASS
-    ) {
-      catProp.category = PropertyCategory.DATA_OPTIONS_SNAPSHOT;
-    // RUNTIME ENGINE PROPS
-    } else if (
-      catProp.name === PropertyName.HEARTBEAT_INTERVAL_MS ||
-      catProp.name === PropertyName.HEARTBEAT_TOPICS_PREFIX ||
-      catProp.name === PropertyName.HEARTBEAT_ACTION_QUERY
-    ) {
-      catProp.category = PropertyCategory.RUNTIME_OPTIONS_HEARTBEAT;
-    } else if (
-      catProp.name === PropertyName.EVENT_PROCESSING_FAILURE_HANDLING_MODE ||
-      catProp.name === PropertyName.MAX_BATCH_SIZE ||
-      catProp.name === PropertyName.MAX_QUEUE_SIZE ||
-      catProp.name === PropertyName.POLL_INTERVAL_MS
-    ) {
-      catProp.category = PropertyCategory.RUNTIME_OPTIONS_ENGINE;
-    }
-  }
-
-  // --------------------------------
-  // Identify the required properties
-  // --------------------------------
-  const requiredProps = [...categorizedProps];
-  for (const reqProp of requiredProps) {
-    if (
-      reqProp.name === PropertyName.DATABASE_SERVER_NAME ||
-      reqProp.name === PropertyName.DATABASE_DBNAME ||
-      reqProp.name === PropertyName.DATABASE_HOSTNAME ||
-      reqProp.name === PropertyName.DATABASE_PORT ||
-      reqProp.name === PropertyName.DATABASE_USER ||
-      reqProp.name === PropertyName.DATABASE_PASSWORD ||
-      reqProp.name === PropertyName.DATABASE_TCPKEEPALIVE ||
-      reqProp.name === PropertyName.PLUGIN_NAME ||
-      reqProp.name === PropertyName.PUBLICATION_NAME ||
-      reqProp.name === PropertyName.PUBLICATION_AUTOCREATE_MODE ||
-      reqProp.name === PropertyName.SLOT_NAME ||
-      reqProp.name === PropertyName.SLOT_DROP_ON_STOP ||
-      reqProp.name === PropertyName.DECIMAL_HANDLING_MODE ||
-      reqProp.name === PropertyName.HSTORE_HANDLING_MODE ||
-      reqProp.name === PropertyName.BINARY_HANDLING_MODE ||
-      reqProp.name === PropertyName.INTERVAL_HANDLING_MODE ||
-      reqProp.name === PropertyName.TIME_PRECISION_MODE
-    ) {
-      reqProp.required = true;
-    } else {
-      reqProp.required = false;
-    }
-  }
-
   // ---------------------------------------
   // Set input type
   // ---------------------------------------
-  const setInputTypeProps = [...categorizedProps];
+  const setInputTypeProps = [...propertyDefns];
   for (const inputProp of setInputTypeProps) {
     if (
       inputProp.name === PropertyName.PLUGIN_NAME ||
@@ -243,20 +117,20 @@ export function getCategorizedPropertyDefinitions(propertyDefns: ConnectorProper
   // ---------------------------------------
   // Set property ordering within category
   // ---------------------------------------
-  const orderedProps = [...requiredProps];
+  const orderedProps = [...setInputTypeProps];
   for (const orderedProp of orderedProps) {
     if ( orderedProp.category === PropertyCategory.BASIC ) {
-      if ( orderedProp.name === PropertyName.DATABASE_HOSTNAME ) {
+      if ( orderedProp.name === PropertyName.DATABASE_SERVER_NAME ) {
         orderedProp.orderInCategory = 1;
-      } else if ( orderedProp.name === PropertyName.DATABASE_PORT ) {
+      } else if ( orderedProp.name === PropertyName.DATABASE_HOSTNAME ) {
         orderedProp.orderInCategory = 2;
-      } else if ( orderedProp.name === PropertyName.DATABASE_USER ) {
+      } else if ( orderedProp.name === PropertyName.DATABASE_PORT ) {
         orderedProp.orderInCategory = 3;
-      } else if ( orderedProp.name === PropertyName.DATABASE_PASSWORD ) {
+      } else if ( orderedProp.name === PropertyName.DATABASE_USER ) {
         orderedProp.orderInCategory = 4;
-      } else if ( orderedProp.name === PropertyName.DATABASE_DBNAME ) {
+      } else if ( orderedProp.name === PropertyName.DATABASE_PASSWORD ) {
         orderedProp.orderInCategory = 5;
-      } else if ( orderedProp.name === PropertyName.DATABASE_SERVER_NAME ) {
+      } else if ( orderedProp.name === PropertyName.DATABASE_DBNAME ) {
         orderedProp.orderInCategory = 6;
       }
     } else if ( orderedProp.category === PropertyCategory.ADVANCED_GENERAL ) {
@@ -270,14 +144,18 @@ export function getCategorizedPropertyDefinitions(propertyDefns: ConnectorProper
         orderedProp.orderInCategory = 1;
       } else if ( orderedProp.name === PropertyName.SLOT_NAME ) {
         orderedProp.orderInCategory = 2;
-      } else if ( orderedProp.name === PropertyName.SLOT_DROP_ON_STOP ) {
-        orderedProp.orderInCategory = 3;
       } else if ( orderedProp.name === PropertyName.SLOT_STREAM_PARAMS ) {
+        orderedProp.orderInCategory = 3;
+      } else if ( orderedProp.name === PropertyName.SLOT_DROP_ON_STOP ) {
         orderedProp.orderInCategory = 4;
       } else if ( orderedProp.name === PropertyName.SLOT_MAX_RETRIES ) {
         orderedProp.orderInCategory = 5;
       } else if ( orderedProp.name === PropertyName.SLOT_RETRY_DELAY_MS ) {
         orderedProp.orderInCategory = 6;
+      } else if ( orderedProp.name === PropertyName.STATUS_UPDATE_INTERVAL_MS ) {
+        orderedProp.orderInCategory = 7;
+      } else if ( orderedProp.name === PropertyName.XMIN_FETCH_INTERVAL_MS ) {
+        orderedProp.orderInCategory = 8;
       }
     } else if ( orderedProp.category === PropertyCategory.ADVANCED_PUBLICATION ) {
       if ( orderedProp.name === PropertyName.PUBLICATION_NAME ) {
@@ -299,61 +177,71 @@ export function getCategorizedPropertyDefinitions(propertyDefns: ConnectorProper
       } else if ( orderedProp.name === PropertyName.COLUMN_BLACKLIST ) {
         orderedProp.orderInCategory = 6;
       }
-    } else if ( orderedProp.category === PropertyCategory.DATA_OPTIONS_TYPE_MAPPING ) {
-      if ( orderedProp.name === PropertyName.TIME_PRECISION_MODE ) {
+    } else if ( orderedProp.category === PropertyCategory.DATA_OPTIONS_GENERAL ) {
+      if( orderedProp.name === PropertyName.TOMBSTONES_ON_DELETE ) {
         orderedProp.orderInCategory = 1;
-      } else if ( orderedProp.name === PropertyName.BINARY_HANDLING_MODE ) {
-        orderedProp.orderInCategory = 2;
       } else if ( orderedProp.name === PropertyName.DECIMAL_HANDLING_MODE ) {
+        orderedProp.orderInCategory = 2;
+      } else if ( orderedProp.name === PropertyName.TIME_PRECISION_MODE ) {
         orderedProp.orderInCategory = 3;
       } else if ( orderedProp.name === PropertyName.INTERVAL_HANDLING_MODE ) {
         orderedProp.orderInCategory = 4;
-      } else if ( orderedProp.name === PropertyName.HSTORE_HANDLING_MODE ) {
+      } else if ( orderedProp.name === PropertyName.BINARY_HANDLING_MODE ) {
         orderedProp.orderInCategory = 5;
-      } else if( orderedProp.name.startsWith(PropertyName.TOMBSTONES_ON_DELETE) ) {
+      } else if ( orderedProp.name === PropertyName.HSTORE_HANDLING_MODE ) {
         orderedProp.orderInCategory = 6;
-      } else if( orderedProp.name.startsWith(PropertyName.MESSAGE_KEY_COLUMNS) ) {
-        orderedProp.orderInCategory = 7;
-      } else if( orderedProp.name.startsWith(PropertyName.COLUMN_TRUNCATE_PREFIX) ) {
-        orderedProp.orderInCategory = 8;
-      } else if ( orderedProp.name.startsWith(PropertyName.COLUMN_MASK_HASH_PREFIX) ) {
-        orderedProp.orderInCategory = 9;
-      } else if ( orderedProp.name.startsWith(PropertyName.COLUMN_MASK_WITH_PREFIX) ) {
-        orderedProp.orderInCategory = 10;
-      } else if ( orderedProp.name === PropertyName.INCLUDE_UNKNOWN_DATATYPES ) {
-        orderedProp.orderInCategory = 11;
-      } else if ( orderedProp.name === PropertyName.TOASTED_VALUE_PLACEHOLDER ) {
-        orderedProp.orderInCategory = 12;
-      } else if ( orderedProp.name === PropertyName.PROVIDE_TRANSACTION_METADATA ) {
-        orderedProp.orderInCategory = 13;
+      } 
+    } else if ( orderedProp.category === PropertyCategory.DATA_OPTIONS_ADVANCED ) {
+      if ( orderedProp.name === PropertyName.CONVERTERS ) {
+        orderedProp.orderInCategory = 1;
       } else if ( orderedProp.name === PropertyName.SCHEMA_REFRESH_MODE ) {
-        orderedProp.orderInCategory = 14;
+        orderedProp.orderInCategory = 2;
+      } else if( orderedProp.name.startsWith(PropertyName.COLUMN_TRUNCATE_PREFIX) ) {
+        orderedProp.orderInCategory = 3;
+      } else if ( orderedProp.name.startsWith(PropertyName.COLUMN_MASK_WITH_PREFIX) ) {
+        orderedProp.orderInCategory = 4;
+      } else if ( orderedProp.name.startsWith(PropertyName.COLUMN_MASK_HASH_PREFIX) ) {
+        orderedProp.orderInCategory = 5;
+      } else if( orderedProp.name === PropertyName.MESSAGE_KEY_COLUMNS ) {
+        orderedProp.orderInCategory = 6;
+      } else if ( orderedProp.name === PropertyName.INCLUDE_UNKNOWN_DATATYPES ) {
+        orderedProp.orderInCategory = 7;
+      } else if ( orderedProp.name === PropertyName.TOASTED_VALUE_PLACEHOLDER ) {
+        orderedProp.orderInCategory = 8;
+      } else if ( orderedProp.name === PropertyName.PROVIDE_TRANSACTION_METADATA ) {
+        orderedProp.orderInCategory = 9;
       } else if ( orderedProp.name === PropertyName.SANITIZE_FIELD_NAMES ) {
-        orderedProp.orderInCategory = 15;
+        orderedProp.orderInCategory = 10;
       }
     } else if ( orderedProp.category === PropertyCategory.DATA_OPTIONS_SNAPSHOT ) {
       if ( orderedProp.name === PropertyName.SNAPSHOT_MODE ) {
         orderedProp.orderInCategory = 1;
-      } else if ( orderedProp.name === PropertyName.SNAPSHOT_CUSTOM_CLASS ) {
-        orderedProp.orderInCategory = 2;
-      } else if ( orderedProp.name === PropertyName.SNAPSHOT_LOCK_TIMEOUT_MS ) {
-        orderedProp.orderInCategory = 3;
-      } else if ( orderedProp.name === PropertyName.SNAPSHOT_SELECT_STATEMENT_OVERRIDES ) {
-        orderedProp.orderInCategory = 4;
-      } else if ( orderedProp.name === PropertyName.SNAPSHOT_DELAY_MS ) {
-        orderedProp.orderInCategory = 5;
       } else if ( orderedProp.name === PropertyName.SNAPSHOT_FETCH_SIZE ) {
+        orderedProp.orderInCategory = 2;
+      } else if ( orderedProp.name === PropertyName.SNAPSHOT_DELAY_MS ) {
+        orderedProp.orderInCategory = 3;
+      } else if ( orderedProp.name === PropertyName.SNAPSHOT_LOCK_TIMEOUT_MS ) {
+        orderedProp.orderInCategory = 4;
+      } else if ( orderedProp.name === PropertyName.SNAPSHOT_SELECT_STATEMENT_OVERRIDES ) {
+        orderedProp.orderInCategory = 5;
+      } else if ( orderedProp.name === PropertyName.SNAPSHOT_CUSTOM_CLASS ) {
         orderedProp.orderInCategory = 6;
       }
     } else if ( orderedProp.category === PropertyCategory.RUNTIME_OPTIONS_ENGINE ) {
-      if ( orderedProp.name === PropertyName.EVENT_PROCESSING_FAILURE_HANDLING_MODE ) {
+      if ( orderedProp.name === PropertyName.SKIPPED_OPERATIONS ) {
         orderedProp.orderInCategory = 1;
-      } else if ( orderedProp.name === PropertyName.MAX_QUEUE_SIZE ) {
+      } else if ( orderedProp.name === PropertyName.EVENT_PROCESSING_FAILURE_HANDLING_MODE ) {
         orderedProp.orderInCategory = 2;
       } else if ( orderedProp.name === PropertyName.MAX_BATCH_SIZE ) {
         orderedProp.orderInCategory = 3;
-      } else if ( orderedProp.name === PropertyName.POLL_INTERVAL_MS ) {
+      } else if ( orderedProp.name === PropertyName.MAX_QUEUE_SIZE ) {
         orderedProp.orderInCategory = 4;
+      } else if ( orderedProp.name === PropertyName.POLL_INTERVAL_MS ) {
+        orderedProp.orderInCategory = 5;
+      } else if ( orderedProp.name === PropertyName.RETRIABLE_RESTART_CONNECTOR_WAIT_MS ) {
+        orderedProp.orderInCategory = 6;
+      } else if ( orderedProp.name === PropertyName.SOURCE_STRUCT_VERSION ) {
+        orderedProp.orderInCategory = 7;
       } 
     } else if ( orderedProp.category === PropertyCategory.RUNTIME_OPTIONS_HEARTBEAT ) {
       if ( orderedProp.name === PropertyName.HEARTBEAT_INTERVAL_MS ) {

--- a/ui/packages/ui/src/app/shared/Utils.ts
+++ b/ui/packages/ui/src/app/shared/Utils.ts
@@ -92,7 +92,8 @@ export function getDataOptionsPropertyDefinitions(
   const connProperties: ConnectorProperty[] = [];
   for (const propDefn of propertyDefns) {
     if (
-      propDefn.category === PropertyCategory.DATA_OPTIONS_TYPE_MAPPING ||
+      propDefn.category === PropertyCategory.DATA_OPTIONS_GENERAL ||
+      propDefn.category === PropertyCategory.DATA_OPTIONS_ADVANCED ||
       propDefn.category === PropertyCategory.DATA_OPTIONS_SNAPSHOT
     ) {
       connProperties.push(propDefn);


### PR DESCRIPTION
Additional work to adapt to the service additions and refine properties 
- updated the ConnectorProperty model: category and isMandatory are no longer optional - they are supplied by the service.  Added 'allowedValues' attribute.  Aligned the category names to match those being supplied by the service.
- CategoryUtils - Removed specification of category and required since they are now supplied by the service.  Added some missing properties and fixed some ordering.
- ConfigureConnectorTypeForm - did some reorganization to put the properties into titled areas.  Also added some logic which hides the publication group if 'plugin' != Pgoutput.
- Created a generic 'FormComponent' - this component handles the logic to determine which specific form element is suitable for the supplied ConnectorProperty.  It will require further refinement - for example determining checkbox vs switch for booleans
- Now utilizing the FormComponent in ConfigureConnectorTypeForm