### PR TITLE
Adjustments to form components

### DIFF
--- a/ui/packages/models/src/ui.model.ts
+++ b/ui/packages/models/src/ui.model.ts
@@ -68,7 +68,7 @@ export interface ConnectionValidationResult {
  */
 // tslint:disable-next-line: interface-name
 export interface ConnectorProperty {
-    allowedValues: string[];
+    allowedValues?: string[];
     category: 'CONNECTION' | 
     'CONNECTION_ADVANCED' | 
     'CONNECTION_ADVANCED_REPLICATION' | 
@@ -81,6 +81,7 @@ export interface ConnectorProperty {
     'ADVANCED' | 
     'ADVANCED_HEARTBEAT'
     ;
+    defaultValue?: any;
     description: string;
     displayName: string;
     name: string;

--- a/ui/packages/ui/src/app/pages/createConnector/CreateConnectorPage.tsx
+++ b/ui/packages/ui/src/app/pages/createConnector/CreateConnectorPage.tsx
@@ -166,6 +166,7 @@ export const CreateConnectorPage: React.FunctionComponent = () => {
   };
 
   const validateProperties = (propertyValues: Map<string, string>) => {
+    // alert("Validate Properties: " + JSON.stringify(mapToObject(propertyValues)));
     const connectorService = Services.getConnectorService();
     fetch_retry(connectorService.validateConnection, connectorService, [
       "postgres",

--- a/ui/packages/ui/src/app/pages/createConnector/connectorSteps/ConfigureConnectorTypeForm.tsx
+++ b/ui/packages/ui/src/app/pages/createConnector/connectorSteps/ConfigureConnectorTypeForm.tsx
@@ -123,16 +123,19 @@ export const ConfigureConnectorTypeForm: React.FunctionComponent<IConfigureConne
   const handleSubmit = (valueMap: Map<string, string>) => {
     // the basic properties
     const basicValueMap: Map<string, string> = new Map();
-    for (const basicVal of props.basicPropertyDefinitions) {
-      basicValueMap.set(basicVal.name, valueMap[basicVal.name]);
+    for (const basicProp of props.basicPropertyDefinitions) {
+      if ( typeof basicProp.defaultValue === 'undefined' || basicProp.defaultValue !== valueMap[basicProp.name] ) {
+        basicValueMap.set(basicProp.name, valueMap[basicProp.name]);
+      }
     }
     // the advance properties
     const advancedValueMap: Map<string, string> = new Map();
-    for (const advancedValue of props.advancedPropertyDefinitions) {
-      advancedValueMap.set(advancedValue.name, valueMap[advancedValue.name]);
+    for (const advancedProp of props.advancedPropertyDefinitions) {
+      if ( typeof advancedProp.defaultValue === 'undefined' || advancedProp.defaultValue !== valueMap[advancedProp.name] ) {
+        advancedValueMap.set(advancedProp.name, valueMap[advancedProp.name]);
+      }
     }
     props.onValidateProperties(basicValueMap, advancedValueMap);
-
   };
 
   return (

--- a/ui/packages/ui/src/app/pages/createConnector/connectorSteps/shared/FormCheckboxComponent.tsx
+++ b/ui/packages/ui/src/app/pages/createConnector/connectorSteps/shared/FormCheckboxComponent.tsx
@@ -10,7 +10,7 @@ export interface IFormCheckboxComponentProps {
 }
 
 export const FormCheckboxComponent: React.FunctionComponent<IFormCheckboxComponentProps> = props => {
-  const [checked, setChecked] = React.useState(true);
+  const [checked, setChecked] = React.useState(props.isChecked);
   const [field] = useField(props);
   
   const handleChange = (value: boolean) => {

--- a/ui/packages/ui/src/app/pages/createConnector/connectorSteps/shared/FormComponent.tsx
+++ b/ui/packages/ui/src/app/pages/createConnector/connectorSteps/shared/FormComponent.tsx
@@ -32,7 +32,7 @@ export const FormComponent: React.FunctionComponent<IFormComponentProps> = (
   } else if (props.propertyDefinition.type === "BOOLEAN") {
     return (
       <FormCheckboxComponent
-        isChecked={props.propertyDefinition.defaultValue || false}
+        isChecked={typeof props.propertyDefinition.defaultValue !== 'undefined' && props.propertyDefinition.defaultValue === true}
         label={props.propertyDefinition.displayName}
         name={props.propertyDefinition.name}
         propertyChange={props.propertyChange}

--- a/ui/packages/ui/src/app/pages/createConnector/connectorSteps/shared/FormInputComponent.tsx
+++ b/ui/packages/ui/src/app/pages/createConnector/connectorSteps/shared/FormInputComponent.tsx
@@ -15,7 +15,7 @@ export interface IFormInputComponentProps {
   infoTitle: string | '';
   helperTextInvalid?: any;
   type: any;
-  isRequired?: boolean | undefined;
+  isRequired: boolean;
   validated?: "default" | "success" | "warning" | "error" | undefined
 }
 export const FormInputComponent: React.FunctionComponent<IFormInputComponentProps> = props => {
@@ -23,7 +23,7 @@ export const FormInputComponent: React.FunctionComponent<IFormInputComponentProp
   return (
     <FormGroup 
       label={props.label}
-      isRequired={props.isRequired !== undefined ? true: false}
+      isRequired={props.isRequired}
       labelIcon={
         <HelpInfoIcon label={props.label} description={props.infoText} />
       }


### PR DESCRIPTION
Address a couple issues with form components
- allowedValues and defaultValue are optional in the model
- ConfigureConnectorTypeForm - the value is included for validation if a property has no default, or if the form value is different than the default
- other adjustments to form component for init
