### PR TITLE
* fixed dependents validation again:

### DIFF
--- a/backend/src/main/java/io/debezium/configserver/service/ConnectorIntegratorBase.java
+++ b/backend/src/main/java/io/debezium/configserver/service/ConnectorIntegratorBase.java
@@ -113,8 +113,8 @@ public abstract class ConnectorIntegratorBase implements ConnectorIntegrator {
     private List<PropertyValidationResult> toPropertyValidationResults(Config result) {
         return result.configValues()
                 .stream()
-                .filter(ConfigValue::visible)
                 .filter(cv -> !cv.errorMessages().isEmpty())
+                .filter(cv -> !cv.errorMessages().get(0).equals(cv.name() + " is referred in the dependents, but not defined."))
                 .map(cv -> new PropertyValidationResult(cv.name(), cv.errorMessages().get(0)))
                 .collect(Collectors.toList());
     }


### PR DESCRIPTION
Excluding invisible fields lead to that other invisible fields are not validated at all (e.g. SCHEMA_EXLUDE_LIST / SCHEMA_BLACKLIST).
they are invisible and should not be ignored. Had to introduce a dirty string comparison until we have validation result instances on Debezium side and we can figure out if a validation error is a WARNing or ERRor.