### PR TITLE
reorganize data options, add connector name input

### DIFF
--- a/ui/packages/models/src/ui.model.ts
+++ b/ui/packages/models/src/ui.model.ts
@@ -76,6 +76,7 @@ export interface ConnectorProperty {
     'CONNECTION_ADVANCED_SSL' | 
     'FILTERS' |
     'CONNECTOR' |
+    'CONNECTOR_NAME' | 
     'CONNECTOR_ADVANCED' | 
     'CONNECTOR_SNAPSHOT' | 
     'ADVANCED' | 

--- a/ui/packages/ui/src/app/pages/createConnector/connectorSteps/ConfigureConnectorTypeComponent.tsx
+++ b/ui/packages/ui/src/app/pages/createConnector/connectorSteps/ConfigureConnectorTypeComponent.tsx
@@ -54,8 +54,16 @@ export const ConfigureConnectorTypeComponent: React.FC<any> = React.forwardRef(
         return key;
       });
     };
+
+    const namePropertyDefinitions = formatPropertyDefinitions(
+      props.basicPropertyDefinitions.filter(
+        (defn: any) => defn.category === PropertyCategory.CONNECTOR_NAME
+      )
+    );
     const basicPropertyDefinitions = formatPropertyDefinitions(
-      props.basicPropertyDefinitions
+      props.basicPropertyDefinitions.filter(
+        (defn: any) => defn.category === PropertyCategory.BASIC
+      )
     );
     const advancedGeneralPropertyDefinitions = formatPropertyDefinitions(
       props.advancedPropertyDefinitions.filter(
@@ -73,8 +81,11 @@ export const ConfigureConnectorTypeComponent: React.FC<any> = React.forwardRef(
       )
     );
 
-    // Just added String and Password type
-    basicPropertyDefinitions.map((key: any) => {
+    const allBasicDefinitions = _.union(
+        namePropertyDefinitions,
+        basicPropertyDefinitions
+      );
+    allBasicDefinitions.map((key: any) => {
       if (key.type === "STRING") {
         basicValidationSchema[key.name] = Yup.string();
       } else if (key.type === "PASSWORD") {
@@ -129,6 +140,7 @@ export const ConfigureConnectorTypeComponent: React.FC<any> = React.forwardRef(
 
     const initialValues = getInitialValues(
       _.union(
+        namePropertyDefinitions,
         basicPropertyDefinitions,
         advancedGeneralPropertyDefinitions,
         advancedReplicationPropertyDefinitions,
@@ -167,6 +179,27 @@ export const ConfigureConnectorTypeComponent: React.FC<any> = React.forwardRef(
         >
           {({ errors, touched, handleChange, isSubmitting, validateForm }) => (
             <Form className="pf-c-form">
+              <Grid hasGutter={true}>
+                {namePropertyDefinitions.map(
+                  (propertyDefinition: ConnectorProperty, index: any) => {
+                    return (
+                      <GridItem key={index}>
+                        <FormComponent
+                          propertyDefinition={propertyDefinition}
+                          propertyChange={handlePropertyChange}
+                          helperTextInvalid={errors[propertyDefinition.name]}
+                          validated={
+                            errors[propertyDefinition.name] &&
+                            touched[propertyDefinition.name]
+                              ? "error"
+                              : "default"
+                          }
+                        />
+                      </GridItem>
+                    );
+                  }
+                )}
+              </Grid>
               <Accordion asDefinitionList={true}>
                 <AccordionItem>
                   <AccordionToggle

--- a/ui/packages/ui/src/app/pages/createConnector/connectorSteps/dataOptions/DataOptionsComponent.css
+++ b/ui/packages/ui/src/app/pages/createConnector/connectorSteps/dataOptions/DataOptionsComponent.css
@@ -3,3 +3,10 @@
     margin: 20px 0
   }
 }
+
+.data-options-component {
+  &-grouping {
+    margin-top: 30px;
+    margin-bottom: 10px;
+  }
+}

--- a/ui/packages/ui/src/app/pages/createConnector/connectorSteps/dataOptions/DataOptionsComponent.tsx
+++ b/ui/packages/ui/src/app/pages/createConnector/connectorSteps/dataOptions/DataOptionsComponent.tsx
@@ -6,12 +6,14 @@ import {
   AccordionToggle,
   Grid,
   GridItem,
+  Title,
 } from "@patternfly/react-core";
 import { Form, Formik, useFormikContext } from "formik";
 import _ from "lodash";
 import * as React from "react";
 import { PropertyCategory } from "src/app/shared";
 import { FormComponent } from "../shared";
+import "./DataOptionsComponent.css";
 
 export interface IDataOptionsComponentProps {
   propertyDefinitions: ConnectorProperty[];
@@ -44,11 +46,14 @@ export const DataOptionsComponent: React.FC<any> = React.forwardRef(
         return key;
       });
     };
-    const mappingPropertyDefinitions = formatPropertyDefinitions(
+    const mappingGeneralPropertyDefinitions = formatPropertyDefinitions(
       props.propertyDefinitions.filter(
-        (defn: any) =>
-          defn.category === PropertyCategory.DATA_OPTIONS_GENERAL ||
-          defn.category === PropertyCategory.DATA_OPTIONS_ADVANCED
+        (defn: any) => defn.category === PropertyCategory.DATA_OPTIONS_GENERAL
+      )
+    );
+    const mappingAdvancedPropertyDefinitions = formatPropertyDefinitions(
+      props.propertyDefinitions.filter(
+        (defn: any) => defn.category === PropertyCategory.DATA_OPTIONS_ADVANCED
       )
     );
     const snapshotPropertyDefinitions = formatPropertyDefinitions(
@@ -91,7 +96,7 @@ export const DataOptionsComponent: React.FC<any> = React.forwardRef(
     };
 
     const initialValues = getInitialValues(
-      _.union(mappingPropertyDefinitions, snapshotPropertyDefinitions)
+      _.union(mappingGeneralPropertyDefinitions, mappingAdvancedPropertyDefinitions, snapshotPropertyDefinitions)
     );
 
     const handleSubmit = (valueMap: Map<string, string>) => {
@@ -180,7 +185,32 @@ export const DataOptionsComponent: React.FC<any> = React.forwardRef(
                     isHidden={!expanded.includes("advanced")}
                   >
                     <Grid hasGutter={true}>
-                      {mappingPropertyDefinitions.map(
+                      {mappingGeneralPropertyDefinitions.map(
+                        (propertyDefinition: ConnectorProperty, index) => {
+                          return (
+                            <GridItem key={index}>
+                              <FormComponent
+                                propertyDefinition={propertyDefinition}
+                                // propertyChange={handlePropertyChange}
+                                helperTextInvalid={
+                                  errors[propertyDefinition.name]
+                                }
+                                validated={
+                                  errors[propertyDefinition.name] &&
+                                  touched[propertyDefinition.name]
+                                    ? "error"
+                                    : "default"
+                                }
+                                propertyChange={handlePropertyChange}
+                              />
+                            </GridItem>
+                          );
+                        }
+                      )}
+                    </Grid>
+                    <Title headingLevel="h2" className={"data-options-component-grouping"}>Advanced properties</Title>
+                    <Grid hasGutter={true}>
+                      {mappingAdvancedPropertyDefinitions.map(
                         (propertyDefinition: ConnectorProperty, index) => {
                           return (
                             <GridItem key={index}>

--- a/ui/packages/ui/src/app/pages/createConnector/connectorSteps/runtimeOptions/RuntimeOptionsComponent.tsx
+++ b/ui/packages/ui/src/app/pages/createConnector/connectorSteps/runtimeOptions/RuntimeOptionsComponent.tsx
@@ -1,5 +1,5 @@
 import { ConnectorProperty } from "@debezium/ui-models/dist/js/ui.model";
-import { Grid, GridItem, Title } from "@patternfly/react-core";
+import { Accordion, AccordionContent, AccordionItem, AccordionToggle, Grid, GridItem } from "@patternfly/react-core";
 import { Form, Formik, useFormikContext } from "formik";
 import _ from "lodash";
 import * as React from "react";
@@ -31,6 +31,7 @@ const FormSubmit: React.FunctionComponent<any> = React.forwardRef(
 
 export const RuntimeOptionsComponent: React.FC<any> = React.forwardRef(
   (props, ref) => {
+    const [expanded, setExpanded] = React.useState<string[]>(["engine","heartbeat"]);
     const basicValidationSchema = {};
 
     const formatPropertyDefinitions = (propertyValues: ConnectorProperty[]) => {
@@ -72,6 +73,22 @@ export const RuntimeOptionsComponent: React.FC<any> = React.forwardRef(
 
     const handlePropertyChange = (propName: string, propValue: any) => {
       // TODO: handling for property change if needed.
+    };
+
+    const toggle = (
+      e: React.MouseEvent<HTMLButtonElement, MouseEvent>,
+      id: string
+    ) => {
+      e.preventDefault();
+      const index = expanded.indexOf(id);
+      const newExpanded =
+        index >= 0
+          ? [
+              ...expanded.slice(0, index),
+              ...expanded.slice(index + 1, expanded.length),
+            ]
+          : [...expanded, id];
+      setExpanded(newExpanded);
     };
 
     const getInitialValues = (combined: any) => {
@@ -120,51 +137,90 @@ export const RuntimeOptionsComponent: React.FC<any> = React.forwardRef(
         >
           {({ errors, touched, handleChange, isSubmitting }) => (
             <Form className="pf-c-form">
-              <Title headingLevel="h2">Engine properties</Title>
-              <Grid hasGutter={true}>
-                {enginePropertyDefinitions.map(
-                  (propertyDefinition: ConnectorProperty, index) => {
-                    return (
-                      <GridItem key={index}>
-                        <FormComponent
-                          propertyDefinition={propertyDefinition}
-                          // propertyChange={handlePropertyChange}
-                          helperTextInvalid={errors[propertyDefinition.name]}
-                          validated={
-                            errors[propertyDefinition.name] &&
-                            touched[propertyDefinition.name]
-                              ? "error"
-                              : "default"
-                          }
-                          propertyChange={handlePropertyChange}
-                        />
-                      </GridItem>
-                    );
-                  }
-                )}
-              </Grid>
-              <Title headingLevel="h2">Heartbeat properties</Title>
-              <Grid hasGutter={true}>
-                {heartbeatPropertyDefinitions.map(
-                  (propertyDefinition: ConnectorProperty, index) => {
-                    return (
-                      <GridItem key={index}>
-                        <FormComponent
-                          propertyDefinition={propertyDefinition}
-                          propertyChange={handlePropertyChange}
-                          helperTextInvalid={errors[propertyDefinition.name]}
-                          validated={
-                            errors[propertyDefinition.name] &&
-                            touched[propertyDefinition.name]
-                              ? "error"
-                              : "default"
-                          }
-                        />
-                      </GridItem>
-                    );
-                  }
-                )}
-              </Grid>
+              <Accordion asDefinitionList={true}>
+                <AccordionItem>
+                  <AccordionToggle
+                    onClick={(e) => {
+                      toggle(e, "engine");
+                    }}
+                    isExpanded={expanded.includes("engine")}
+                    id="engine"
+                    className="dbz-c-accordion"
+                  >
+                    Engine properties
+                  </AccordionToggle>
+                  <AccordionContent
+                    id="engine"
+                    className="dbz-c-accordion__content"
+                    isHidden={!expanded.includes("engine")}
+                  >
+                    <Grid hasGutter={true}>
+                      {enginePropertyDefinitions.map(
+                        (propertyDefinition: ConnectorProperty, index) => {
+                          return (
+                            <GridItem key={index}>
+                              <FormComponent
+                                propertyDefinition={propertyDefinition}
+                                // propertyChange={handlePropertyChange}
+                                helperTextInvalid={
+                                  errors[propertyDefinition.name]
+                                }
+                                validated={
+                                  errors[propertyDefinition.name] &&
+                                  touched[propertyDefinition.name]
+                                    ? "error"
+                                    : "default"
+                                }
+                                propertyChange={handlePropertyChange}
+                              />
+                            </GridItem>
+                          );
+                        }
+                      )}
+                    </Grid>
+                  </AccordionContent>
+                </AccordionItem>
+                <AccordionItem>
+                  <AccordionToggle
+                    onClick={(e) => {
+                      toggle(e, "heartbeat");
+                    }}
+                    isExpanded={expanded.includes("heartbeat")}
+                    id="heartbeat"
+                    className="dbz-c-accordion"
+                  >
+                    Heartbeat properties
+                  </AccordionToggle>
+                  <AccordionContent
+                    id="heartbeat"
+                    isHidden={!expanded.includes("heartbeat")}
+                  >
+                    <Grid hasGutter={true}>
+                      {heartbeatPropertyDefinitions.map(
+                        (propertyDefinition: ConnectorProperty, index) => {
+                          return (
+                            <GridItem key={index}>
+                              <FormComponent
+                                propertyDefinition={propertyDefinition}
+                                propertyChange={handlePropertyChange}
+                                helperTextInvalid={
+                                  errors[propertyDefinition.name]
+                                }
+                                validated={
+                                  errors[propertyDefinition.name] &&
+                                  touched[propertyDefinition.name]
+                                    ? "error"
+                                    : "default"
+                                }
+                              />
+                            </GridItem>
+                          );
+                        }
+                      )}
+                    </Grid>
+                  </AccordionContent>
+                </AccordionItem>
+              </Accordion>
               <FormSubmit ref={ref} />
             </Form>
           )}

--- a/ui/packages/ui/src/app/shared/Utils.ts
+++ b/ui/packages/ui/src/app/shared/Utils.ts
@@ -8,7 +8,8 @@ export enum ConnectorTypeId {
 }
 
 export enum PropertyName {
-  DATABASE_SERVER_NAME = 'database.server.name',
+  CONNECTOR_NAME = "connector.name",
+  DATABASE_SERVER_NAME = "database.server.name",
   DATABASE_DBNAME = "database.dbname",
   DATABASE_HOSTNAME = "database.hostname",
   DATABASE_PORT = "database.port",
@@ -73,6 +74,7 @@ export enum PropertyName {
 }
 
 export enum PropertyCategory {
+  CONNECTOR_NAME = "CONNECTOR_NAME",
   BASIC = "CONNECTION",
   ADVANCED_GENERAL = "CONNECTION_ADVANCED",
   ADVANCED_REPLICATION = "CONNECTION_ADVANCED_REPLICATION",
@@ -121,6 +123,17 @@ export function getBasicPropertyDefinitions(
       connProperties.push(propDefn);
     }
   }
+  // Add a property for the Connector name
+  const connNameProperty = {
+    category: PropertyCategory.CONNECTOR_NAME,
+    description: "The connector name",
+    displayName: "Connector name",
+    name: "connector.name",
+    isMandatory: true,
+    type: "STRING"
+  } as ConnectorProperty;
+  connProperties.push(connNameProperty);
+
   return connProperties;
 }
 
@@ -197,6 +210,25 @@ export function getRuntimeOptionsPropertyDefinitions(
     }
   }
   return connProperties;
+}
+
+/**
+ * Determine if the supplied category is one of the Data Options
+ * @param propertyCategory the category
+ */
+export function isDataOptions (propertyCategory: PropertyCategory): boolean {
+  return (propertyCategory === PropertyCategory.DATA_OPTIONS_GENERAL ||
+          propertyCategory === PropertyCategory.DATA_OPTIONS_ADVANCED ||
+          propertyCategory === PropertyCategory.DATA_OPTIONS_SNAPSHOT);
+}
+
+/**
+ * Determine if the supplied category is one of the Runtime Options
+ * @param propertyCategory the category
+ */
+export function isRuntimeOptions (propertyCategory: PropertyCategory): boolean {
+  return (propertyCategory === PropertyCategory.RUNTIME_OPTIONS_ENGINE ||
+          propertyCategory === PropertyCategory.RUNTIME_OPTIONS_HEARTBEAT);
 }
 
 export function mapToObject(inputMap: Map<string, string>) {


### PR DESCRIPTION
- Reorganized Data Options step to better match the mockups
- Reorganized Runtime Options step - put property groups into accordions, to be consistent with other steps
- added connector name property into the basic properties.  The connection name is displayed at the top of the property configuration page.  Now passing the entered connector name upon create of the connector.
- other minor wording changes and clean up