### PR TITLE
Validation update and persistence of user value on 2nd step, proper e…

### DIFF
--- a/ui/packages/ui/src/app/pages/createConnector/CreateConnectorPage.tsx
+++ b/ui/packages/ui/src/app/pages/createConnector/CreateConnectorPage.tsx
@@ -129,7 +129,7 @@ export const CreateConnectorPage: React.FunctionComponent = () => {
     setConnectorCreateFailed(false);
 
     // Cluster ID and connector name for the create
-    const clusterID =  location.state.value;
+    const clusterID =  location.state?.value;
     const connectorName = basicPropValues.get(PropertyName.CONNECTOR_NAME);
 
     // Merge the individual category properties values into a single map for the config
@@ -220,12 +220,12 @@ export const CreateConnectorPage: React.FunctionComponent = () => {
     setBasicPropValues(basicPropertyValues);
     setAdvancedPropValues(advancePropertyValues);
     // Don't include connector name for validation
-    const basicForValidation = new Map<string,string>(basicPropertyValues);
-    basicForValidation.delete(PropertyName.CONNECTOR_NAME);
+    // const basicForValidation = new Map<string,string>(basicPropertyValues);
+    // basicForValidation.delete(PropertyName.CONNECTOR_NAME);
     validateConnectionProperties(
       new Map(
         (function*() {
-          yield* basicForValidation;
+          yield* basicPropertyValues;
           yield* advancePropertyValues;
         })()
       )
@@ -260,7 +260,8 @@ export const CreateConnectorPage: React.FunctionComponent = () => {
           for (const e1 of result.propertyValidationResults) {
             resultStr = `${resultStr}\n${e1.property}: ${e1.message}`;
           }
-          alert(
+          // tslint:disable-next-line: no-console
+          console.log(
             "connection props are INVALID. Property Results: \n" + resultStr
           );
         } else {
@@ -384,6 +385,8 @@ export const CreateConnectorPage: React.FunctionComponent = () => {
             advancedPropertyValues={advancedPropValues}
             onValidateProperties={handleValidateConnectionProperties}
             ref={connectionPropsRef}
+            setConnectionPropsValid={setConnectionPropsValid}
+            setConnectionStepsValid={setConnectionStepsValid}
           />
         </>
       ),

--- a/ui/packages/ui/src/app/pages/createConnector/connectorSteps/ConfigureConnectorTypeComponent.tsx
+++ b/ui/packages/ui/src/app/pages/createConnector/connectorSteps/ConfigureConnectorTypeComponent.tsx
@@ -21,6 +21,8 @@ export interface IConfigureConnectorTypeComponentProps {
   basicPropertyValues: Map<string, string>;
   advancedPropertyDefinitions: ConnectorProperty[];
   advancedPropertyValues: Map<string, string>;
+  setConnectionPropsValid: () => void;
+  setConnectionStepsValid: () => void;
   onValidateProperties: (
     basicPropertyValues: Map<string, string>,
     advancePropertyValues: Map<string, string>
@@ -29,13 +31,20 @@ export interface IConfigureConnectorTypeComponentProps {
 
 const FormSubmit: React.FunctionComponent<any> = React.forwardRef(
   (props, ref) => {
-    const { submitForm, validateForm } = useFormikContext();
+    const { dirty, submitForm, validateForm } = useFormikContext();
+
     React.useImperativeHandle(ref, () => ({
       validate() {
         validateForm();
         submitForm();
       },
     }));
+    React.useEffect(() => {
+      if (dirty) {
+        props.setConnectionPropsValid(!dirty);
+        props.setConnectionStepsValid(0);
+      }
+    }, [props.setConnectionPropsValid, dirty]);
     return null;
   }
 );
@@ -82,9 +91,9 @@ export const ConfigureConnectorTypeComponent: React.FC<any> = React.forwardRef(
     );
 
     const allBasicDefinitions = _.union(
-        namePropertyDefinitions,
-        basicPropertyDefinitions
-      );
+      namePropertyDefinitions,
+      basicPropertyDefinitions
+    );
     allBasicDefinitions.map((key: any) => {
       if (key.type === "STRING") {
         basicValidationSchema[key.name] = Yup.string();
@@ -120,12 +129,22 @@ export const ConfigureConnectorTypeComponent: React.FC<any> = React.forwardRef(
 
     const getInitialValues = (combined: any) => {
       const combinedValue: any = {};
+      const userValues: Map<string, string> = new Map([
+        ...props.basicPropertyValues,
+        ...props.advancedPropertyValues,
+      ]);
 
       combined.map((key: { name: string; defaultValue: string }) => {
         if (!combinedValue[key.name]) {
-          key.defaultValue === undefined
-            ? (combinedValue[key.name] = "")
-            : (combinedValue[key.name] = key.defaultValue);
+          if (userValues.size === 0) {
+            key.defaultValue === undefined
+              ? (combinedValue[key.name] = "")
+              : (combinedValue[key.name] = key.defaultValue);
+          } else {
+            combinedValue[key.name] = userValues.get(
+              key.name.replace(/_/g, ".")
+            );
+          }
         }
       });
       return combinedValue;
@@ -167,6 +186,8 @@ export const ConfigureConnectorTypeComponent: React.FC<any> = React.forwardRef(
           initialValues={initialValues}
           validationSchema={validationSchema}
           onSubmit={(values) => {
+            // tslint:disable-next-line: no-console
+            console.log("submit", values);
             let valueMap = new Map<string, string>();
             valueMap = _.transform(
               values,
@@ -348,7 +369,11 @@ export const ConfigureConnectorTypeComponent: React.FC<any> = React.forwardRef(
                   </AccordionContent>
                 </AccordionItem>
               </Accordion>
-              <FormSubmit ref={ref} />
+              <FormSubmit
+                ref={ref}
+                setConnectionPropsValid={props.setConnectionPropsValid}
+                setConnectionStepsValid={props.setConnectionStepsValid}
+              />
             </Form>
           )}
         </Formik>

--- a/ui/packages/ui/src/app/pages/createConnector/connectorSteps/ConfigureConnectorTypeComponent.tsx
+++ b/ui/packages/ui/src/app/pages/createConnector/connectorSteps/ConfigureConnectorTypeComponent.tsx
@@ -186,8 +186,6 @@ export const ConfigureConnectorTypeComponent: React.FC<any> = React.forwardRef(
           initialValues={initialValues}
           validationSchema={validationSchema}
           onSubmit={(values) => {
-            // tslint:disable-next-line: no-console
-            console.log("submit", values);
             let valueMap = new Map<string, string>();
             valueMap = _.transform(
               values,

--- a/ui/packages/ui/src/app/pages/createConnector/connectorSteps/FiltersStepComponent.tsx
+++ b/ui/packages/ui/src/app/pages/createConnector/connectorSteps/FiltersStepComponent.tsx
@@ -1,8 +1,4 @@
-import {
-  ConnectorProperty,
-  DataCollection,
-  FilterValidationResult,
-} from "@debezium/ui-models";
+import { DataCollection, FilterValidationResult } from "@debezium/ui-models";
 import { Services } from "@debezium/ui-services";
 import {
   ActionGroup,
@@ -21,7 +17,11 @@ import {
   ToggleGroup,
   ToggleGroupItem,
 } from "@patternfly/react-core";
-import { HelpIcon, InfoCircleIcon } from "@patternfly/react-icons";
+import {
+  ExclamationCircleIcon,
+  HelpIcon,
+  InfoCircleIcon,
+} from "@patternfly/react-icons";
 import _ from "lodash";
 import React from "react";
 import { FilterTreeComponent } from "src/app/components";
@@ -75,6 +75,19 @@ const getTableExpression = (data: Map<string, string>): string => {
   return data.get("table.exclude.list") || data.get("table.include.list") || "";
 };
 
+const getInvalidFilterMsg = (
+  filter: string,
+  errorMsg: Map<string, string> | undefined
+) => {
+  let returnVal = "";
+  errorMsg?.forEach((val, key) => {
+    if (key.includes(filter)) {
+      returnVal = val;
+    }
+  });
+  return returnVal;
+};
+
 export const FiltersStepComponent: React.FunctionComponent<IFiltersStepComponentProps> = (
   props
 ) => {
@@ -99,7 +112,7 @@ export const FiltersStepComponent: React.FunctionComponent<IFiltersStepComponent
     new Map()
   );
   const [treeData, setTreeData] = React.useState<any[]>([]);
-  const [invalidMsg, setInvalidMsg] = React.useState<string>("");
+  const [invalidMsg, setInvalidMsg] = React.useState<Map<string, string>>();
   const [tableNo, setTableNo] = React.useState<number>(0);
   const [showClearDialog, setShowClearDialog] = React.useState<boolean>(false);
 
@@ -145,15 +158,15 @@ export const FiltersStepComponent: React.FunctionComponent<IFiltersStepComponent
       .then((result: FilterValidationResult) => {
         setLoading(false);
         if (result.status === "INVALID") {
-          let resultStr = "";
-          for (const e1 of result.propertyValidationResults) {
-            resultStr = `${resultStr}\n${e1.property}: ${e1.message}`;
+          const errorMap = new Map();
+          for (const e of result.propertyValidationResults) {
+            errorMap.set(e.property, e.message);
           }
-          setInvalidMsg(resultStr);
+          setInvalidMsg(errorMap);
         } else {
           // tslint:disable-next-line: no-unused-expression
           saveFilter && props.updateFilterValues(filterExpression);
-          setInvalidMsg("");
+          setInvalidMsg(new Map());
           setTableNo(result.matchedCollections.length);
           setTreeData(formatResponseData(result.matchedCollections));
         }
@@ -253,11 +266,28 @@ export const FiltersStepComponent: React.FunctionComponent<IFiltersStepComponent
               </button>
             </Popover>
           }
+          helperTextInvalid={
+            invalidMsg?.size !== 0
+              ? getInvalidFilterMsg("schema", invalidMsg)
+              : ""
+          }
+          helperTextInvalidIcon={<ExclamationCircleIcon />}
+          validated={
+            invalidMsg?.size !== 0 && getInvalidFilterMsg("schema", invalidMsg)
+              ? "error"
+              : "default"
+          }
         >
           <Flex>
             <FlexItem>
               <TextInput
                 value={schemaFilter}
+                validated={
+                  invalidMsg?.size !== 0 &&
+                  getInvalidFilterMsg("schema", invalidMsg)
+                    ? "error"
+                    : "default"
+                }
                 type="text"
                 id="schema_filter"
                 aria-describedby="schema_filter-helper"
@@ -316,10 +346,27 @@ export const FiltersStepComponent: React.FunctionComponent<IFiltersStepComponent
               </button>
             </Popover>
           }
+          helperTextInvalid={
+            invalidMsg?.size !== 0
+              ? getInvalidFilterMsg("table", invalidMsg)
+              : ""
+          }
+          helperTextInvalidIcon={<ExclamationCircleIcon />}
+          validated={
+            invalidMsg?.size !== 0 && getInvalidFilterMsg("table", invalidMsg)
+              ? "error"
+              : "default"
+          }
         >
           <Flex>
             <FlexItem>
               <TextInput
+                validated={
+                  invalidMsg?.size !== 0 &&
+                  getInvalidFilterMsg("schema", invalidMsg)
+                    ? "error"
+                    : "default"
+                }
                 value={tableFilter}
                 onChange={handleTableFilter}
                 type="text"
@@ -360,7 +407,7 @@ export const FiltersStepComponent: React.FunctionComponent<IFiltersStepComponent
         </ActionGroup>
       </Form>
       <Divider />
-      {invalidMsg !== "" ? (
+      {invalidMsg?.size !== 0 ? (
         <Alert
           variant={"danger"}
           isInline={true}

--- a/ui/packages/ui/src/app/pages/createConnector/connectorSteps/FiltersStepComponent.tsx
+++ b/ui/packages/ui/src/app/pages/createConnector/connectorSteps/FiltersStepComponent.tsx
@@ -363,7 +363,7 @@ export const FiltersStepComponent: React.FunctionComponent<IFiltersStepComponent
               <TextInput
                 validated={
                   invalidMsg?.size !== 0 &&
-                  getInvalidFilterMsg("schema", invalidMsg)
+                  getInvalidFilterMsg("table", invalidMsg)
                     ? "error"
                     : "default"
                 }


### PR DESCRIPTION
- Updated the validation on the connector property step(2nd). Now if the user updates the form after validation or by going back he is required to revalidate the form values.

- Persistence of the user entered values on the connector property step while going back and forth.

- Proper handling of the error in case of invalid filter, by identifying the problematic filter and showing msg coming from the backend. 
![image](https://user-images.githubusercontent.com/8264372/93765484-95cc9b00-fc32-11ea-9c5b-cb208e5e3504.png)
