### PR TITLE
Send properties to backend

### DIFF
--- a/ui/packages/ui/src/app/pages/createConnector/CreateConnectorPage.tsx
+++ b/ui/packages/ui/src/app/pages/createConnector/CreateConnectorPage.tsx
@@ -2,7 +2,8 @@ import {
   ConnectionValidationResult,
   ConnectorProperty,
   ConnectorType,
-  PropertiesValidationResult
+
+  PropertiesValidationResult, PropertyValidationResult
 } from "@debezium/ui-models";
 import { Services } from "@debezium/ui-services";
 import {
@@ -33,7 +34,7 @@ import {
   isRuntimeOptions,
   mapToObject,
   PropertyCategory,
-  PropertyName,
+  PropertyName
 } from "src/app/shared";
 import {
   ConfigureConnectorTypeComponent,
@@ -105,6 +106,9 @@ export const CreateConnectorPage: React.FunctionComponent = () => {
   const [connectionPropsValid, setConnectionPropsValid] = React.useState<
     boolean
   >(false);
+
+  const [connectionPropsValidMsg, setConnectionPropsValidMsg] = React.useState<PropertyValidationResult[]>([]);
+
   const [dataOptionsValid, setDataOptionsValid] = React.useState<boolean>(
     false
   );
@@ -244,11 +248,11 @@ export const CreateConnectorPage: React.FunctionComponent = () => {
     validateOptionProperties(propertyValues, propertyCategory);
   };
 
+  // Validation Connection Properties Step
   const validateConnectionProperties = (
     propertyValues: Map<string, string>
   ) => {
     // alert("Validate Properties: " + JSON.stringify(mapToObject(propertyValues)));
-
     const connectorService = Services.getConnectorService();
     fetch_retry(connectorService.validateConnection, connectorService, [
       selectedConnectorType,
@@ -260,10 +264,7 @@ export const CreateConnectorPage: React.FunctionComponent = () => {
           for (const e1 of result.propertyValidationResults) {
             resultStr = `${resultStr}\n${e1.property}: ${e1.message}`;
           }
-          // tslint:disable-next-line: no-console
-          console.log(
-            "connection props are INVALID. Property Results: \n" + resultStr
-          );
+          setConnectionPropsValidMsg(result.propertyValidationResults)
         } else {
           setConnectionPropsValid(true);
         }
@@ -290,9 +291,7 @@ export const CreateConnectorPage: React.FunctionComponent = () => {
           for (const e1 of result.propertyValidationResults) {
             resultStr = `${resultStr}\n${e1.property}: ${e1.message}`;
           }
-          alert(
-            "connection props are INVALID. Property Results: \n" + resultStr
-          );
+          setConnectionPropsValidMsg(result.propertyValidationResults)
         } else {
           if ( isDataOptions(propertyCategory) ) {
             setDataOptionsValid(true);
@@ -337,6 +336,23 @@ export const CreateConnectorPage: React.FunctionComponent = () => {
     initPropertyValues();
   }, [connectorTypes]);
 
+  const ConnectionPropertiesError = ({ connectionPropsMsg }) => {
+    if(connectionPropsMsg.length !== 0){
+      return(
+        <ul>
+          {connectionPropsMsg.map((item, index) => (
+            <li key={index}>{item.property}: {item.message}</li>
+          ))}
+        </ul>
+      )
+    }else{
+      return(
+      <div>{validationErrorMsg}</div>
+      )
+    }
+
+  }
+
   const wizardSteps = [
     {
       id: 1,
@@ -363,7 +379,7 @@ export const CreateConnectorPage: React.FunctionComponent = () => {
               <div style={{ padding: "15px 0" }}>
                 <Alert
                   variant="danger"
-                  title={validationErrorMsg}
+                  title={<ConnectionPropertiesError connectionPropsMsg={connectionPropsValidMsg} />}
                 />
               </div>
             ) : (
@@ -415,7 +431,7 @@ export const CreateConnectorPage: React.FunctionComponent = () => {
               <div style={{ padding: "15px 0" }}>
                 <Alert
                   variant="danger"
-                  title={validationErrorMsg}
+                  title={<ConnectionPropertiesError connectionPropsMsg={connectionPropsValidMsg} />}
                 />
               </div>
             ) : (
@@ -449,7 +465,7 @@ export const CreateConnectorPage: React.FunctionComponent = () => {
               <div style={{ padding: "15px 0" }}>
                 <Alert
                   variant="danger"
-                  title={validationErrorMsg}
+                  title={<ConnectionPropertiesError connectionPropsMsg={connectionPropsValidMsg} />}
                 />
               </div>
             ) : (

--- a/ui/packages/ui/src/app/pages/createConnector/CreateConnectorPage.tsx
+++ b/ui/packages/ui/src/app/pages/createConnector/CreateConnectorPage.tsx
@@ -44,7 +44,6 @@ import {
   RuntimeOptionsComponent
 } from "./connectorSteps";
 import "./CreateConnectorPage.css";
-
 /**
  * Put the enabled types first, then the disabled types.  alpha sort each group
  * @param connectorTypes
@@ -133,13 +132,13 @@ export const CreateConnectorPage: React.FunctionComponent = () => {
     setConnectorCreateFailed(false);
 
     // Cluster ID and connector name for the create
-    const clusterID =  location.state?.value;
+    const clusterID = location.state?.value;
     const connectorName = basicPropValues.get(PropertyName.CONNECTOR_NAME);
 
     // Merge the individual category properties values into a single map for the config
     const allPropValues = new Map<string, string>();
     // Remove connector name from basic, so not passed with properties
-    const basicValuesTemp = new Map<string,string>(basicPropValues);
+    const basicValuesTemp = new Map<string, string>(basicPropValues);
     basicValuesTemp.delete(PropertyName.CONNECTOR_NAME);
     basicValuesTemp.forEach((v, k) => { allPropValues.set(k, v) });
 
@@ -228,7 +227,7 @@ export const CreateConnectorPage: React.FunctionComponent = () => {
     // basicForValidation.delete(PropertyName.CONNECTOR_NAME);
     validateConnectionProperties(
       new Map(
-        (function*() {
+        (function* () {
           yield* basicPropertyValues;
           yield* advancePropertyValues;
         })()
@@ -240,9 +239,9 @@ export const CreateConnectorPage: React.FunctionComponent = () => {
     propertyValues: Map<string, string>,
     propertyCategory: PropertyCategory
   ): void => {
-    if ( isDataOptions(propertyCategory) ) {
+    if (isDataOptions(propertyCategory)) {
       setDataOptionsPropValues(propertyValues);
-    } else if ( isRuntimeOptions(propertyCategory) ) {
+    } else if (isRuntimeOptions(propertyCategory)) {
       setRuntimeOptionsPropValues(propertyValues);
     }
     validateOptionProperties(propertyValues, propertyCategory);
@@ -260,10 +259,16 @@ export const CreateConnectorPage: React.FunctionComponent = () => {
     ])
       .then((result: ConnectionValidationResult) => {
         if (result.status === "INVALID") {
-          let resultStr = "";
-          for (const e1 of result.propertyValidationResults) {
-            resultStr = `${resultStr}\n${e1.property}: ${e1.message}`;
+          const connectorPropertyDefns = _.union(getBasicPropertyDefinitions(selectedConnectorPropertyDefns), getAdvancedPropertyDefinitions(selectedConnectorPropertyDefns));
+          for (const connectionValue of connectorPropertyDefns) {
+            const propertyName = connectionValue.name.replace(/_/g, ".");
+            for (const msg in result.propertyValidationResults) {
+              if (result.propertyValidationResults[msg].property === propertyName) {
+                result.propertyValidationResults[msg].displayName = connectionValue.displayName;
+              }
+            }
           }
+
           setConnectionPropsValidMsg(result.propertyValidationResults)
         } else {
           setConnectionPropsValid(true);
@@ -287,15 +292,36 @@ export const CreateConnectorPage: React.FunctionComponent = () => {
     ])
       .then((result: PropertiesValidationResult) => {
         if (result.status === "INVALID") {
-          let resultStr = "";
-          for (const e1 of result.propertyValidationResults) {
-            resultStr = `${resultStr}\n${e1.property}: ${e1.message}`;
+          if (isDataOptions(propertyCategory)) {
+            const connectorPropertyDefns = getDataOptionsPropertyDefinitions(
+              selectedConnectorPropertyDefns
+            );
+            for (const connectionValue of connectorPropertyDefns) {
+              const propertyName = connectionValue.name.replace(/_/g, ".");
+              for (const msg in result.propertyValidationResults) {
+                if (result.propertyValidationResults[msg].property === propertyName) {
+                  result.propertyValidationResults[msg].displayName = connectionValue.displayName;
+                }
+              }
+            }
+          } else if (isRuntimeOptions(propertyCategory)) {
+            const connectorPropertyDefns = getDataOptionsPropertyDefinitions(
+              selectedConnectorPropertyDefns
+            );
+            for (const connectionValue of connectorPropertyDefns) {
+              const propertyName = connectionValue.name.replace(/_/g, ".");
+              for (const msg in result.propertyValidationResults) {
+                if (result.propertyValidationResults[msg].property === propertyName) {
+                  result.propertyValidationResults[msg].displayName = connectionValue.displayName;
+                }
+              }
+            }
           }
           setConnectionPropsValidMsg(result.propertyValidationResults)
         } else {
-          if ( isDataOptions(propertyCategory) ) {
+          if (isDataOptions(propertyCategory)) {
             setDataOptionsValid(true);
-          } else if ( isRuntimeOptions(propertyCategory) ) {
+          } else if (isRuntimeOptions(propertyCategory)) {
             setRuntimeOptionsValid(true);
           }
         }
@@ -337,17 +363,17 @@ export const CreateConnectorPage: React.FunctionComponent = () => {
   }, [connectorTypes]);
 
   const ConnectionPropertiesError = ({ connectionPropsMsg }) => {
-    if(connectionPropsMsg.length !== 0){
-      return(
+    if (connectionPropsMsg.length !== 0) {
+      return (
         <ul>
           {connectionPropsMsg.map((item, index) => (
-            <li key={index}>{item.property}: {item.message}</li>
+            <li key={index}>{item.displayName}: {item.message}</li>
           ))}
         </ul>
       )
-    }else{
-      return(
-      <div>{validationErrorMsg}</div>
+    } else {
+      return (
+        <div>{validationErrorMsg}</div>
       )
     }
 
@@ -383,13 +409,13 @@ export const CreateConnectorPage: React.FunctionComponent = () => {
                 />
               </div>
             ) : (
-              <div style={{ padding: "15px 0" }}>
-                <Alert
-                  variant="success"
-                  title={validationSuccessNextMsg}
-                />
-              </div>
-            ))}
+                <div style={{ padding: "15px 0" }}>
+                  <Alert
+                    variant="success"
+                    title={validationSuccessNextMsg}
+                  />
+                </div>
+              ))}
           <ConfigureConnectorTypeComponent
             basicPropertyDefinitions={getBasicPropertyDefinitions(
               selectedConnectorPropertyDefns
@@ -435,13 +461,13 @@ export const CreateConnectorPage: React.FunctionComponent = () => {
                 />
               </div>
             ) : (
-              <div style={{ padding: "15px 0" }}>
-                <Alert
-                  variant="success"
-                  title={validationSuccessNextMsg}
-                />
-              </div>
-            ))}
+                <div style={{ padding: "15px 0" }}>
+                  <Alert
+                    variant="success"
+                    title={validationSuccessNextMsg}
+                  />
+                </div>
+              ))}
           <DataOptionsComponent
             propertyDefinitions={getDataOptionsPropertyDefinitions(
               selectedConnectorPropertyDefns
@@ -469,13 +495,13 @@ export const CreateConnectorPage: React.FunctionComponent = () => {
                 />
               </div>
             ) : (
-              <div style={{ padding: "15px 0" }}>
-                <Alert
-                  variant="success"
-                  title={validationSuccessFinishMsg}
-                />
-              </div>
-            ))}
+                <div style={{ padding: "15px 0" }}>
+                  <Alert
+                    variant="success"
+                    title={validationSuccessFinishMsg}
+                  />
+                </div>
+              ))}
           {connectorCreateFailed && (
             <div style={{ padding: "15px 0" }}>
               <Alert variant="danger" title="Create of the connector failed." />
@@ -542,10 +568,10 @@ export const CreateConnectorPage: React.FunctionComponent = () => {
                   Finish
                 </Button>
               ) : (
-                <Button variant="primary" type="submit" onClick={onNext}>
-                  Next
-                </Button>
-              )}
+                  <Button variant="primary" type="submit" onClick={onNext}>
+                    Next
+                  </Button>
+                )}
               <Button
                 variant="secondary"
                 onClick={onBack}

--- a/ui/packages/ui/src/app/pages/createConnector/connectorSteps/ConfigureConnectorTypeComponent.tsx
+++ b/ui/packages/ui/src/app/pages/createConnector/connectorSteps/ConfigureConnectorTypeComponent.tsx
@@ -6,12 +6,12 @@ import {
   AccordionToggle,
   Grid,
   GridItem,
-  Title,
+  Title
 } from "@patternfly/react-core";
 import { Form, Formik, useFormikContext } from "formik";
 import _ from "lodash";
 import * as React from "react";
-import { PropertyCategory, PropertyName } from "src/app/shared";
+import { formatPropertyDefinitions, PropertyCategory, PropertyName } from "src/app/shared";
 import * as Yup from "yup";
 import "./ConfigureConnectorTypeComponent.css";
 import { FormComponent } from "./shared";
@@ -55,15 +55,7 @@ export const ConfigureConnectorTypeComponent: React.FC<any> = React.forwardRef(
     const [showPublication, setShowPublication] = React.useState(true);
 
     const basicValidationSchema = {};
-
-    const formatPropertyDefinitions = (propertyValues: ConnectorProperty[]) => {
-      const propertyValuesCopy = JSON.parse(JSON.stringify(propertyValues));
-      return propertyValuesCopy.map((key: { name: string }) => {
-        key.name = key.name.replace(/\./g, "_");
-        return key;
-      });
-    };
-
+    
     const namePropertyDefinitions = formatPropertyDefinitions(
       props.basicPropertyDefinitions.filter(
         (defn: any) => defn.category === PropertyCategory.CONNECTOR_NAME
@@ -170,12 +162,12 @@ export const ConfigureConnectorTypeComponent: React.FC<any> = React.forwardRef(
       // the basic properties
       const basicValueMap: Map<string, string> = new Map();
       for (const basicVal of props.basicPropertyDefinitions) {
-        basicValueMap.set(basicVal.name, valueMap[basicVal.name]);
+        basicValueMap.set(basicVal.name.replace(/_/g, "."), valueMap[basicVal.name]);
       }
       // the advance properties
       const advancedValueMap: Map<string, string> = new Map();
       for (const advancedValue of props.advancedPropertyDefinitions) {
-        advancedValueMap.set(advancedValue.name, valueMap[advancedValue.name]);
+        advancedValueMap.set(advancedValue.name.replace(/_/g, "."), valueMap[advancedValue.name]);
       }
       props.onValidateProperties(basicValueMap, advancedValueMap);
     };
@@ -186,14 +178,7 @@ export const ConfigureConnectorTypeComponent: React.FC<any> = React.forwardRef(
           initialValues={initialValues}
           validationSchema={validationSchema}
           onSubmit={(values) => {
-            let valueMap = new Map<string, string>();
-            valueMap = _.transform(
-              values,
-              (result, val: string, key: string) => {
-                result[key.replace(/_/g, ".")] = val;
-              }
-            );
-            handleSubmit(valueMap);
+            handleSubmit(values);
           }}
         >
           {({ errors, touched, handleChange, isSubmitting, validateForm }) => (

--- a/ui/packages/ui/src/app/pages/createConnector/connectorSteps/ConnectorTypeStepComponent.css
+++ b/ui/packages/ui/src/app/pages/createConnector/connectorSteps/ConnectorTypeStepComponent.css
@@ -3,6 +3,7 @@
     flex-wrap: wrap;
     justify-content: space-between;
     flex-direction: row;
+    align-items: center;
     & > div {
       text-align: center;
       cursor: pointer;
@@ -12,6 +13,9 @@
     &_disableCard {
       color: var(--pf-global--disabled-color--100);
       background: var(--pf-global--palette--black-150);
+    }
+    .pf-c-card{
+      min-height: 220px;
     }
   }
   &_dbIcon {

--- a/ui/packages/ui/src/app/pages/createConnector/connectorSteps/ConnectorTypeStepComponent.tsx
+++ b/ui/packages/ui/src/app/pages/createConnector/connectorSteps/ConnectorTypeStepComponent.tsx
@@ -42,7 +42,6 @@ export const ConnectorTypeStepComponent: React.FunctionComponent<IConnectorTypeS
         : newId;
     props.onSelectionChange(newSelection);
   };
-  console.log(props.connectorTypesList)
   return (
     <WithLoader
       error={props.apiError}
@@ -68,7 +67,7 @@ export const ConnectorTypeStepComponent: React.FunctionComponent<IConnectorTypeS
                   <CardHeaderMain
                     className={"connector-type-step-component_dbIcon"}
                   >
-                    <ConnectorIcon connectorType={cType.id} alt={cType.displayName} width={cType.id === "mysql" ? 72: 50} />
+                    <ConnectorIcon connectorType={cType.id} alt={cType.displayName} width={50} />
                   </CardHeaderMain>
                 </CardHeader>
                 <CardTitle>{cType.displayName}</CardTitle>

--- a/ui/packages/ui/src/app/pages/createConnector/connectorSteps/ConnectorTypeStepComponent.tsx
+++ b/ui/packages/ui/src/app/pages/createConnector/connectorSteps/ConnectorTypeStepComponent.tsx
@@ -42,7 +42,7 @@ export const ConnectorTypeStepComponent: React.FunctionComponent<IConnectorTypeS
         : newId;
     props.onSelectionChange(newSelection);
   };
-
+  console.log(props.connectorTypesList)
   return (
     <WithLoader
       error={props.apiError}
@@ -68,7 +68,7 @@ export const ConnectorTypeStepComponent: React.FunctionComponent<IConnectorTypeS
                   <CardHeaderMain
                     className={"connector-type-step-component_dbIcon"}
                   >
-                    <ConnectorIcon connectorType={cType.id} alt={cType.displayName} width={index !== 2 ? 50: 72} />
+                    <ConnectorIcon connectorType={cType.id} alt={cType.displayName} width={cType.id === "mysql" ? 72: 50} />
                   </CardHeaderMain>
                 </CardHeader>
                 <CardTitle>{cType.displayName}</CardTitle>

--- a/ui/packages/ui/src/app/pages/createConnector/connectorSteps/ConnectorTypeStepComponent.tsx
+++ b/ui/packages/ui/src/app/pages/createConnector/connectorSteps/ConnectorTypeStepComponent.tsx
@@ -6,7 +6,7 @@ import {
   CardHeaderMain,
   CardTitle,
   Flex,
-  FlexItem,
+  FlexItem
 } from "@patternfly/react-core";
 import React from "react";
 import { PageLoader } from "src/app/components";
@@ -68,7 +68,7 @@ export const ConnectorTypeStepComponent: React.FunctionComponent<IConnectorTypeS
                   <CardHeaderMain
                     className={"connector-type-step-component_dbIcon"}
                   >
-                    <ConnectorIcon connectorType={cType.id} alt={cType.displayName} width={50} />
+                    <ConnectorIcon connectorType={cType.id} alt={cType.displayName} width={index !== 2 ? 50: 72} />
                   </CardHeaderMain>
                 </CardHeader>
                 <CardTitle>{cType.displayName}</CardTitle>

--- a/ui/packages/ui/src/app/pages/createConnector/connectorSteps/dataOptions/DataOptionsComponent.tsx
+++ b/ui/packages/ui/src/app/pages/createConnector/connectorSteps/dataOptions/DataOptionsComponent.tsx
@@ -6,12 +6,12 @@ import {
   AccordionToggle,
   Grid,
   GridItem,
-  Title,
+  Title
 } from "@patternfly/react-core";
 import { Form, Formik, useFormikContext } from "formik";
 import _ from "lodash";
 import * as React from "react";
-import { PropertyCategory } from "src/app/shared";
+import { formatPropertyDefinitions, PropertyCategory } from "src/app/shared";
 import { FormComponent } from "../shared";
 import "./DataOptionsComponent.css";
 
@@ -40,12 +40,7 @@ const FormSubmit: React.FunctionComponent<any> = React.forwardRef(
 export const DataOptionsComponent: React.FC<any> = React.forwardRef(
   (props, ref) => {
     const [expanded, setExpanded] = React.useState<string[]>(["basic"]);
-    const formatPropertyDefinitions = (propertyValues: ConnectorProperty[]) => {
-      return propertyValues.map((key: { name: string }) => {
-        key.name = key.name.replace(/\./g, "_");
-        return key;
-      });
-    };
+
     const mappingGeneralPropertyDefinitions = formatPropertyDefinitions(
       props.propertyDefinitions.filter(
         (defn: any) => defn.category === PropertyCategory.DATA_OPTIONS_GENERAL
@@ -102,7 +97,7 @@ export const DataOptionsComponent: React.FC<any> = React.forwardRef(
     const handleSubmit = (valueMap: Map<string, string>) => {
       const dataValueMap: Map<string, string> = new Map();
       for (const dataValue of props.propertyDefinitions) {
-        dataValueMap.set(dataValue.name, valueMap[dataValue.name]);
+        dataValueMap.set(dataValue.name.replace(/_/g, "."), valueMap[dataValue.name]);
       }
       props.onValidateProperties(
         dataValueMap,
@@ -115,17 +110,10 @@ export const DataOptionsComponent: React.FC<any> = React.forwardRef(
         <Formik
           initialValues={initialValues}
           onSubmit={(values) => {
-            let valueMap = new Map<string, string>();
-            valueMap = _.transform(
-              values,
-              (result, val: string, key: string) => {
-                result[key.replace(/_/g, ".")] = val;
-              }
-            );
-            handleSubmit(valueMap);
+            handleSubmit(values);
           }}
         >
-          {({ errors, touched, setFieldValue, isSubmitting }) => (
+          {({ errors, touched }) => (
             <Form className="pf-c-form">
               <Accordion asDefinitionList={true}>
                 <AccordionItem>
@@ -216,7 +204,6 @@ export const DataOptionsComponent: React.FC<any> = React.forwardRef(
                             <GridItem key={index}>
                               <FormComponent
                                 propertyDefinition={propertyDefinition}
-                                // propertyChange={handlePropertyChange}
                                 helperTextInvalid={
                                   errors[propertyDefinition.name]
                                 }

--- a/ui/packages/ui/src/app/pages/createConnector/connectorSteps/runtimeOptions/RuntimeOptionsComponent.tsx
+++ b/ui/packages/ui/src/app/pages/createConnector/connectorSteps/runtimeOptions/RuntimeOptionsComponent.tsx
@@ -3,7 +3,7 @@ import { Accordion, AccordionContent, AccordionItem, AccordionToggle, Grid, Grid
 import { Form, Formik, useFormikContext } from "formik";
 import _ from "lodash";
 import * as React from "react";
-import { PropertyCategory } from "src/app/shared";
+import { formatPropertyDefinitions, PropertyCategory } from "src/app/shared";
 import * as Yup from "yup";
 import { FormComponent } from "../shared";
 
@@ -34,12 +34,6 @@ export const RuntimeOptionsComponent: React.FC<any> = React.forwardRef(
     const [expanded, setExpanded] = React.useState<string[]>(["engine","heartbeat"]);
     const basicValidationSchema = {};
 
-    const formatPropertyDefinitions = (propertyValues: ConnectorProperty[]) => {
-      return propertyValues.map((key: { name: string }) => {
-        key.name = key.name.replace(/\./g, "_");
-        return key;
-      });
-    };
     const enginePropertyDefinitions = formatPropertyDefinitions(
       props.propertyDefinitions.filter(
         (defn: ConnectorProperty) =>
@@ -111,7 +105,7 @@ export const RuntimeOptionsComponent: React.FC<any> = React.forwardRef(
     const handleSubmit = (valueMap: Map<string, string>) => {
       const runtimeValueMap: Map<string, string> = new Map();
       for (const runtimeValue of props.propertyDefinitions) {
-        runtimeValueMap.set(runtimeValue.name, valueMap[runtimeValue.name]);
+        runtimeValueMap.set(runtimeValue.name.replace(/_/g, "."), valueMap[runtimeValue.name]);
       }
       props.onValidateProperties(
         runtimeValueMap,
@@ -125,17 +119,10 @@ export const RuntimeOptionsComponent: React.FC<any> = React.forwardRef(
           initialValues={initialValues}
           validationSchema={validationSchema}
           onSubmit={(values) => {
-            let valueMap = new Map<string, string>();
-            valueMap = _.transform(
-              values,
-              (result, val: string, key: string) => {
-                result[key.replace(/_/g, ".")] = val;
-              }
-            );
-            handleSubmit(valueMap);
+            handleSubmit(values);
           }}
         >
-          {({ errors, touched, handleChange, isSubmitting }) => (
+          {({ errors, touched }) => (
             <Form className="pf-c-form">
               <Accordion asDefinitionList={true}>
                 <AccordionItem>

--- a/ui/packages/ui/src/app/shared/Utils.ts
+++ b/ui/packages/ui/src/app/shared/Utils.ts
@@ -137,6 +137,15 @@ export function getBasicPropertyDefinitions(
   return connProperties;
 }
 
+export function formatPropertyDefinitions (
+  propertyValues: ConnectorProperty[]
+){
+  return propertyValues.map((key: { name: string }) => {
+    key.name = key.name.replace(/\./g, "_");
+    return key;
+  });
+};
+
 /**
  * Get the advanced properties
  * @param propertyDefns the array of all ConnectorProperty objects


### PR DESCRIPTION
- Improved display of errors coming from backend service when a form is validated.
- Fixed connector type cards have different heights
- Fixed step 4 and 5 not sending data to backend and moved Format Property Definitions function to Utils.