### PR TITLE
Improvements to form layouts

### DIFF
--- a/ui/packages/models/src/ui.model.ts
+++ b/ui/packages/models/src/ui.model.ts
@@ -86,6 +86,7 @@ export interface ConnectorProperty {
     defaultValue?: any;
     description: string;
     displayName: string;
+    gridWidth?: number;
     name: string;
     isMandatory: boolean;
     type: 'BOOLEAN' | 'STRING' | 'INT' | 'SHORT' | 'LONG' | 'DOUBLE' | 'LIST' | 'CLASS' | 'PASSWORD';

--- a/ui/packages/ui/src/app/pages/createConnector/CreateConnectorPage.tsx
+++ b/ui/packages/ui/src/app/pages/createConnector/CreateConnectorPage.tsx
@@ -29,6 +29,7 @@ import {
   getAdvancedPropertyDefinitions,
   getBasicPropertyDefinitions,
   getDataOptionsPropertyDefinitions,
+  getGridFormattedProperties,
   getRuntimeOptionsPropertyDefinitions,
   isDataOptions,
   isRuntimeOptions,
@@ -360,7 +361,7 @@ export const CreateConnectorPage: React.FunctionComponent = () => {
 
     // tslint:disable-next-line: no-unused-expression
     connectorTypes[0]?.properties &&
-      setSelectedConnectorPropertyDefns(connectorTypes[0]!.properties);
+      setSelectedConnectorPropertyDefns(getGridFormattedProperties(connectorTypes[0]!.properties));
 
     // Init the connector property values
     initPropertyValues();

--- a/ui/packages/ui/src/app/pages/createConnector/connectorSteps/ConfigureConnectorTypeComponent.tsx
+++ b/ui/packages/ui/src/app/pages/createConnector/connectorSteps/ConfigureConnectorTypeComponent.tsx
@@ -187,7 +187,7 @@ export const ConfigureConnectorTypeComponent: React.FC<any> = React.forwardRef(
                 {namePropertyDefinitions.map(
                   (propertyDefinition: ConnectorProperty, index: any) => {
                     return (
-                      <GridItem key={index}>
+                      <GridItem key={index} span={4}>
                         <FormComponent
                           propertyDefinition={propertyDefinition}
                           propertyChange={handlePropertyChange}
@@ -204,131 +204,36 @@ export const ConfigureConnectorTypeComponent: React.FC<any> = React.forwardRef(
                   }
                 )}
               </Grid>
-              <Accordion asDefinitionList={true}>
-                <AccordionItem>
-                  <AccordionToggle
-                    onClick={(e) => {
-                      toggle(e, "basic");
-                    }}
-                    isExpanded={expanded.includes("basic")}
-                    id="basic"
-                    className="dbz-c-accordion"
-                  >
-                    Basic Properties
-                  </AccordionToggle>
-                  <AccordionContent
-                    id="basic"
-                    className="dbz-c-accordion__content"
-                    isHidden={!expanded.includes("basic")}
-                  >
-                    <Grid hasGutter={true}>
-                      {basicPropertyDefinitions.map(
-                        (propertyDefinition: ConnectorProperty, index: any) => {
-                          return (
-                            <GridItem key={index}>
-                              <FormComponent
-                                propertyDefinition={propertyDefinition}
-                                propertyChange={handlePropertyChange}
-                                helperTextInvalid={
-                                  errors[propertyDefinition.name]
-                                }
-                                validated={
-                                  errors[propertyDefinition.name] &&
-                                  touched[propertyDefinition.name]
-                                    ? "error"
-                                    : "default"
-                                }
-                              />
-                            </GridItem>
-                          );
-                        }
-                      )}
-                    </Grid>
-                  </AccordionContent>
-                </AccordionItem>
-                <AccordionItem>
-                  <AccordionToggle
-                    onClick={(e) => {
-                      toggle(e, "advanced");
-                    }}
-                    isExpanded={expanded.includes("advanced")}
-                    id="advanced"
-                    className="dbz-c-accordion"
-                  >
-                    Advanced Properties
-                  </AccordionToggle>
-                  <AccordionContent
-                    id="advance"
-                    isHidden={!expanded.includes("advanced")}
-                  >
-                    <Grid hasGutter={true}>
-                      {advancedGeneralPropertyDefinitions.map(
-                        (propertyDefinition: ConnectorProperty, index: any) => {
-                          return (
-                            <GridItem key={index}>
-                              <FormComponent
-                                propertyDefinition={propertyDefinition}
-                                propertyChange={handlePropertyChange}
-                                helperTextInvalid={
-                                  errors[propertyDefinition.name]
-                                }
-                                validated={
-                                  errors[propertyDefinition.name] &&
-                                  touched[propertyDefinition.name]
-                                    ? "error"
-                                    : "default"
-                                }
-                              />
-                            </GridItem>
-                          );
-                        }
-                      )}
-                    </Grid>
-                    <Title
-                      headingLevel="h2"
-                      className="configure-connector-type-form-grouping"
-                    >
-                      Replication
-                    </Title>
-                    <Grid hasGutter={true}>
-                      {advancedReplicationPropertyDefinitions.map(
-                        (propertyDefinition: ConnectorProperty, index: any) => {
-                          return (
-                            <GridItem key={index}>
-                              <FormComponent
-                                propertyDefinition={propertyDefinition}
-                                propertyChange={handlePropertyChange}
-                                helperTextInvalid={
-                                  errors[propertyDefinition.name]
-                                }
-                                validated={
-                                  errors[propertyDefinition.name] &&
-                                  touched[propertyDefinition.name]
-                                    ? "error"
-                                    : "default"
-                                }
-                              />
-                            </GridItem>
-                          );
-                        }
-                      )}
-                    </Grid>
-                    {showPublication && (
-                      <>
-                        <Title
-                          headingLevel="h2"
-                          className="configure-connector-type-form-grouping"
-                        >
-                          Publication
-                        </Title>
+              <Grid>
+                <GridItem span={9}>
+                  <Accordion asDefinitionList={true}>
+                    <AccordionItem>
+                      <AccordionToggle
+                        onClick={(e) => {
+                          toggle(e, "basic");
+                        }}
+                        isExpanded={expanded.includes("basic")}
+                        id="basic"
+                        className="dbz-c-accordion"
+                      >
+                        Basic Properties
+                      </AccordionToggle>
+                      <AccordionContent
+                        id="basic"
+                        className="dbz-c-accordion__content"
+                        isHidden={!expanded.includes("basic")}
+                      >
                         <Grid hasGutter={true}>
-                          {advancedPublicationPropertyDefinitions.map(
+                          {basicPropertyDefinitions.map(
                             (
                               propertyDefinition: ConnectorProperty,
                               index: any
                             ) => {
                               return (
-                                <GridItem key={index}>
+                                <GridItem
+                                  key={index}
+                                  span={propertyDefinition.gridWidth}
+                                >
                                   <FormComponent
                                     propertyDefinition={propertyDefinition}
                                     propertyChange={handlePropertyChange}
@@ -347,11 +252,139 @@ export const ConfigureConnectorTypeComponent: React.FC<any> = React.forwardRef(
                             }
                           )}
                         </Grid>
-                      </>
-                    )}
-                  </AccordionContent>
-                </AccordionItem>
-              </Accordion>
+                      </AccordionContent>
+                    </AccordionItem>
+                    <AccordionItem>
+                      <AccordionToggle
+                        onClick={(e) => {
+                          toggle(e, "advanced");
+                        }}
+                        isExpanded={expanded.includes("advanced")}
+                        id="advanced"
+                        className="dbz-c-accordion"
+                      >
+                        Advanced Properties
+                      </AccordionToggle>
+                      <AccordionContent
+                        id="advance"
+                        isHidden={!expanded.includes("advanced")}
+                      >
+                        <GridItem span={9}>
+                          <Grid hasGutter={true}>
+                            {advancedGeneralPropertyDefinitions.map(
+                              (
+                                propertyDefinition: ConnectorProperty,
+                                index: any
+                              ) => {
+                                return (
+                                  <GridItem
+                                    key={index}
+                                    span={propertyDefinition.gridWidth}
+                                  >
+                                    <FormComponent
+                                      propertyDefinition={propertyDefinition}
+                                      propertyChange={handlePropertyChange}
+                                      helperTextInvalid={
+                                        errors[propertyDefinition.name]
+                                      }
+                                      validated={
+                                        errors[propertyDefinition.name] &&
+                                        touched[propertyDefinition.name]
+                                          ? "error"
+                                          : "default"
+                                      }
+                                    />
+                                  </GridItem>
+                                );
+                              }
+                            )}
+                          </Grid>
+                        </GridItem>
+                        <Title
+                          headingLevel="h2"
+                          className="configure-connector-type-form-grouping"
+                        >
+                          Replication
+                        </Title>
+                        <GridItem span={9}>
+                          <Grid hasGutter={true}>
+                            {advancedReplicationPropertyDefinitions.map(
+                              (
+                                propertyDefinition: ConnectorProperty,
+                                index: any
+                              ) => {
+                                return (
+                                  <GridItem
+                                    key={index}
+                                    span={propertyDefinition.gridWidth}
+                                  >
+                                    <FormComponent
+                                      propertyDefinition={propertyDefinition}
+                                      propertyChange={handlePropertyChange}
+                                      helperTextInvalid={
+                                        errors[propertyDefinition.name]
+                                      }
+                                      validated={
+                                        errors[propertyDefinition.name] &&
+                                        touched[propertyDefinition.name]
+                                          ? "error"
+                                          : "default"
+                                      }
+                                    />
+                                  </GridItem>
+                                );
+                              }
+                            )}
+                          </Grid>
+                        </GridItem>
+                        {showPublication && (
+                          <>
+                            <Title
+                              headingLevel="h2"
+                              className="configure-connector-type-form-grouping"
+                            >
+                              Publication
+                            </Title>
+                            <GridItem span={9}>
+                              <Grid hasGutter={true}>
+                                {advancedPublicationPropertyDefinitions.map(
+                                  (
+                                    propertyDefinition: ConnectorProperty,
+                                    index: any
+                                  ) => {
+                                    return (
+                                      <GridItem
+                                        key={index}
+                                        span={propertyDefinition.gridWidth}
+                                      >
+                                        <FormComponent
+                                          propertyDefinition={
+                                            propertyDefinition
+                                          }
+                                          propertyChange={handlePropertyChange}
+                                          helperTextInvalid={
+                                            errors[propertyDefinition.name]
+                                          }
+                                          validated={
+                                            errors[propertyDefinition.name] &&
+                                            touched[propertyDefinition.name]
+                                              ? "error"
+                                              : "default"
+                                          }
+                                        />
+                                      </GridItem>
+                                    );
+                                  }
+                                )}
+                              </Grid>
+                            </GridItem>
+                          </>
+                        )}
+                      </AccordionContent>
+                    </AccordionItem>
+                  </Accordion>
+                </GridItem>
+              </Grid>
               <FormSubmit
                 ref={ref}
                 setConnectionPropsValid={props.setConnectionPropsValid}

--- a/ui/packages/ui/src/app/pages/createConnector/connectorSteps/FiltersStepComponent.tsx
+++ b/ui/packages/ui/src/app/pages/createConnector/connectorSteps/FiltersStepComponent.tsx
@@ -120,6 +120,9 @@ export const FiltersStepComponent: React.FunctionComponent<IFiltersStepComponent
   const [apiError, setApiError] = React.useState<boolean>(false);
   const [errorMsg, setErrorMsg] = React.useState<Error>(new Error());
 
+  const schemaFilterInfo = "A comma-separated list of regular expressions for schema filtering (e.g schema1,schema2).  Click for more information about regular expressions:";
+  const tableFilterInfo = "A comma-separated list of regular expressions for table filtering (e.g schema1.*,schema2.table1).  Click for more information about regular expressions:";
+
   const handleSchemaFilter = (val: string) => {
     setSchemaFilter(val);
   };
@@ -233,7 +236,7 @@ export const FiltersStepComponent: React.FunctionComponent<IFiltersStepComponent
         Table Selection
       </Title>
       <Text component={TextVariants.h2}>
-        Select tables for change capture by entering comma-separated lists of regular expressions for schemas, tables and columns.
+        Select tables for change capture by entering comma-separated lists of regular expressions for schemas and tables.
       </Text>
       <Form isHorizontal={true} className="filters-step-component_form">
         <FormGroup
@@ -253,7 +256,7 @@ export const FiltersStepComponent: React.FunctionComponent<IFiltersStepComponent
             )
           }
           labelIcon={
-            <Popover bodyContent={<div>e.g schema1,schema2</div>}>
+            <Popover bodyContent={<div>{schemaFilterInfo}<br /><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions" target="_blank">More Info</a></div>}>
               <button
                 aria-label="More info for schema filter field"
                 onClick={(e) => e.preventDefault()}
@@ -333,7 +336,7 @@ export const FiltersStepComponent: React.FunctionComponent<IFiltersStepComponent
             )
           }
           labelIcon={
-            <Popover bodyContent={<div>e.g schema1.*,schema2.table1</div>}>
+            <Popover bodyContent={<div>{tableFilterInfo}<br /><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions" target="_blank">More Info</a></div>}>
               <button
                 aria-label="More info for table filter field"
                 onClick={(e) => e.preventDefault()}

--- a/ui/packages/ui/src/app/pages/createConnector/connectorSteps/dataOptions/DataOptionsComponent.tsx
+++ b/ui/packages/ui/src/app/pages/createConnector/connectorSteps/dataOptions/DataOptionsComponent.tsx
@@ -143,119 +143,132 @@ export const DataOptionsComponent: React.FC<any> = React.forwardRef(
         >
           {({ errors, touched }) => (
             <Form className="pf-c-form">
-              <Accordion asDefinitionList={true}>
-                <AccordionItem>
-                  <AccordionToggle
-                    onClick={(e) => {
-                      toggle(e, "basic");
-                    }}
-                    isExpanded={expanded.includes("basic")}
-                    id="basic"
-                    className="dbz-c-accordion"
-                  >
-                    Snapshot properties
-                  </AccordionToggle>
-                  <AccordionContent
-                    id="basic"
-                    className="dbz-c-accordion__content"
-                    isHidden={!expanded.includes("basic")}
-                  >
-                    <Grid hasGutter={true}>
-                      {snapshotPropertyDefinitions.map(
-                        (propertyDefinition: ConnectorProperty, index) => {
-                          return (
-                            <GridItem key={index}>
-                              <FormComponent
-                                propertyDefinition={propertyDefinition}
-                                propertyChange={handlePropertyChange}
-                                helperTextInvalid={
-                                  errors[propertyDefinition.name]
-                                }
-                                validated={
-                                  errors[propertyDefinition.name] &&
-                                  touched[propertyDefinition.name]
-                                    ? "error"
-                                    : "default"
-                                }
-                              />
-                            </GridItem>
-                          );
-                        }
-                      )}
-                    </Grid>
-                  </AccordionContent>
-                </AccordionItem>
-                <AccordionItem>
-                  <AccordionToggle
-                    onClick={(e) => {
-                      toggle(e, "advanced");
-                    }}
-                    isExpanded={expanded.includes("advanced")}
-                    id="advanced"
-                    className="dbz-c-accordion"
-                  >
-                    Mapping properties
-                  </AccordionToggle>
-                  <AccordionContent
-                    id="advance"
-                    isHidden={!expanded.includes("advanced")}
-                  >
-                    <Grid hasGutter={true}>
-                      {mappingGeneralPropertyDefinitions.map(
-                        (propertyDefinition: ConnectorProperty, index) => {
-                          return (
-                            <GridItem key={index}>
-                              <FormComponent
-                                propertyDefinition={propertyDefinition}
-                                // propertyChange={handlePropertyChange}
-                                helperTextInvalid={
-                                  errors[propertyDefinition.name]
-                                }
-                                validated={
-                                  errors[propertyDefinition.name] &&
-                                  touched[propertyDefinition.name]
-                                    ? "error"
-                                    : "default"
-                                }
-                                propertyChange={handlePropertyChange}
-                              />
-                            </GridItem>
-                          );
-                        }
-                      )}
-                    </Grid>
-                    <Title
-                      headingLevel="h2"
-                      className={"data-options-component-grouping"}
-                    >
-                      Advanced properties
-                    </Title>
-                    <Grid hasGutter={true}>
-                      {mappingAdvancedPropertyDefinitions.map(
-                        (propertyDefinition: ConnectorProperty, index) => {
-                          return (
-                            <GridItem key={index}>
-                              <FormComponent
-                                propertyDefinition={propertyDefinition}
-                                helperTextInvalid={
-                                  errors[propertyDefinition.name]
-                                }
-                                validated={
-                                  errors[propertyDefinition.name] &&
-                                  touched[propertyDefinition.name]
-                                    ? "error"
-                                    : "default"
-                                }
-                                propertyChange={handlePropertyChange}
-                              />
-                            </GridItem>
-                          );
-                        }
-                      )}
-                    </Grid>
-                  </AccordionContent>
-                </AccordionItem>
-              </Accordion>
+              <Grid>
+                <GridItem span={9}>
+                  <Accordion asDefinitionList={true}>
+                    <AccordionItem>
+                      <AccordionToggle
+                        onClick={(e) => {
+                          toggle(e, "basic");
+                        }}
+                        isExpanded={expanded.includes("basic")}
+                        id="basic"
+                        className="dbz-c-accordion"
+                      >
+                        Snapshot properties
+                      </AccordionToggle>
+                      <AccordionContent
+                        id="basic"
+                        className="dbz-c-accordion__content"
+                        isHidden={!expanded.includes("basic")}
+                      >
+                        <Grid hasGutter={true}>
+                          {snapshotPropertyDefinitions.map(
+                            (propertyDefinition: ConnectorProperty, index) => {
+                              return (
+                                <GridItem
+                                  key={index}
+                                  span={propertyDefinition.gridWidth}
+                                >
+                                  <FormComponent
+                                    propertyDefinition={propertyDefinition}
+                                    propertyChange={handlePropertyChange}
+                                    helperTextInvalid={
+                                      errors[propertyDefinition.name]
+                                    }
+                                    validated={
+                                      errors[propertyDefinition.name] &&
+                                      touched[propertyDefinition.name]
+                                        ? "error"
+                                        : "default"
+                                    }
+                                  />
+                                </GridItem>
+                              );
+                            }
+                          )}
+                        </Grid>
+                      </AccordionContent>
+                    </AccordionItem>
+                    <AccordionItem>
+                      <AccordionToggle
+                        onClick={(e) => {
+                          toggle(e, "advanced");
+                        }}
+                        isExpanded={expanded.includes("advanced")}
+                        id="advanced"
+                        className="dbz-c-accordion"
+                      >
+                        Mapping properties
+                      </AccordionToggle>
+                      <AccordionContent
+                        id="advance"
+                        isHidden={!expanded.includes("advanced")}
+                      >
+                        <Grid hasGutter={true}>
+                          {mappingGeneralPropertyDefinitions.map(
+                            (propertyDefinition: ConnectorProperty, index) => {
+                              return (
+                                <GridItem
+                                  key={index}
+                                  span={propertyDefinition.gridWidth}
+                                >
+                                  <FormComponent
+                                    propertyDefinition={propertyDefinition}
+                                    // propertyChange={handlePropertyChange}
+                                    helperTextInvalid={
+                                      errors[propertyDefinition.name]
+                                    }
+                                    validated={
+                                      errors[propertyDefinition.name] &&
+                                      touched[propertyDefinition.name]
+                                        ? "error"
+                                        : "default"
+                                    }
+                                    propertyChange={handlePropertyChange}
+                                  />
+                                </GridItem>
+                              );
+                            }
+                          )}
+                        </Grid>
+                        <Title
+                          headingLevel="h2"
+                          className={"data-options-component-grouping"}
+                        >
+                          Advanced properties
+                        </Title>
+                        <Grid hasGutter={true}>
+                          {mappingAdvancedPropertyDefinitions.map(
+                            (propertyDefinition: ConnectorProperty, index) => {
+                              return (
+                                <GridItem
+                                  key={index}
+                                  span={propertyDefinition.gridWidth}
+                                >
+                                  <FormComponent
+                                    propertyDefinition={propertyDefinition}
+                                    helperTextInvalid={
+                                      errors[propertyDefinition.name]
+                                    }
+                                    validated={
+                                      errors[propertyDefinition.name] &&
+                                      touched[propertyDefinition.name]
+                                        ? "error"
+                                        : "default"
+                                    }
+                                    propertyChange={handlePropertyChange}
+                                  />
+                                </GridItem>
+                              );
+                            }
+                          )}
+                        </Grid>
+                      </AccordionContent>
+                    </AccordionItem>
+                  </Accordion>
+                </GridItem>
+              </Grid>
               <FormSubmit
                 ref={ref}
                 setDataOptionsValid={props.setDataOptionsValid}

--- a/ui/packages/ui/src/app/pages/createConnector/connectorSteps/runtimeOptions/RuntimeOptionsComponent.tsx
+++ b/ui/packages/ui/src/app/pages/createConnector/connectorSteps/runtimeOptions/RuntimeOptionsComponent.tsx
@@ -142,90 +142,100 @@ export const RuntimeOptionsComponent: React.FC<any> = React.forwardRef(
         >
           {({ errors, touched }) => (
             <Form className="pf-c-form">
-              <Accordion asDefinitionList={true}>
-                <AccordionItem>
-                  <AccordionToggle
-                    onClick={(e) => {
-                      toggle(e, "engine");
-                    }}
-                    isExpanded={expanded.includes("engine")}
-                    id="engine"
-                    className="dbz-c-accordion"
-                  >
-                    Engine properties
-                  </AccordionToggle>
-                  <AccordionContent
-                    id="engine"
-                    className="dbz-c-accordion__content"
-                    isHidden={!expanded.includes("engine")}
-                  >
-                    <Grid hasGutter={true}>
-                      {enginePropertyDefinitions.map(
-                        (propertyDefinition: ConnectorProperty, index) => {
-                          return (
-                            <GridItem key={index}>
-                              <FormComponent
-                                propertyDefinition={propertyDefinition}
-                                // propertyChange={handlePropertyChange}
-                                helperTextInvalid={
-                                  errors[propertyDefinition.name]
-                                }
-                                validated={
-                                  errors[propertyDefinition.name] &&
-                                  touched[propertyDefinition.name]
-                                    ? "error"
-                                    : "default"
-                                }
-                                propertyChange={handlePropertyChange}
-                              />
-                            </GridItem>
-                          );
-                        }
-                      )}
-                    </Grid>
-                  </AccordionContent>
-                </AccordionItem>
-                <AccordionItem>
-                  <AccordionToggle
-                    onClick={(e) => {
-                      toggle(e, "heartbeat");
-                    }}
-                    isExpanded={expanded.includes("heartbeat")}
-                    id="heartbeat"
-                    className="dbz-c-accordion"
-                  >
-                    Heartbeat properties
-                  </AccordionToggle>
-                  <AccordionContent
-                    id="heartbeat"
-                    isHidden={!expanded.includes("heartbeat")}
-                  >
-                    <Grid hasGutter={true}>
-                      {heartbeatPropertyDefinitions.map(
-                        (propertyDefinition: ConnectorProperty, index) => {
-                          return (
-                            <GridItem key={index}>
-                              <FormComponent
-                                propertyDefinition={propertyDefinition}
-                                propertyChange={handlePropertyChange}
-                                helperTextInvalid={
-                                  errors[propertyDefinition.name]
-                                }
-                                validated={
-                                  errors[propertyDefinition.name] &&
-                                  touched[propertyDefinition.name]
-                                    ? "error"
-                                    : "default"
-                                }
-                              />
-                            </GridItem>
-                          );
-                        }
-                      )}
-                    </Grid>
-                  </AccordionContent>
-                </AccordionItem>
-              </Accordion>
+              <Grid>
+                <GridItem span={9}>
+                  <Accordion asDefinitionList={true}>
+                    <AccordionItem>
+                      <AccordionToggle
+                        onClick={(e) => {
+                          toggle(e, "engine");
+                        }}
+                        isExpanded={expanded.includes("engine")}
+                        id="engine"
+                        className="dbz-c-accordion"
+                      >
+                        Engine properties
+                      </AccordionToggle>
+                      <AccordionContent
+                        id="engine"
+                        className="dbz-c-accordion__content"
+                        isHidden={!expanded.includes("engine")}
+                      >
+                        <Grid hasGutter={true}>
+                          {enginePropertyDefinitions.map(
+                            (propertyDefinition: ConnectorProperty, index) => {
+                              return (
+                                <GridItem
+                                  key={index}
+                                  span={propertyDefinition.gridWidth}
+                                >
+                                  <FormComponent
+                                    propertyDefinition={propertyDefinition}
+                                    // propertyChange={handlePropertyChange}
+                                    helperTextInvalid={
+                                      errors[propertyDefinition.name]
+                                    }
+                                    validated={
+                                      errors[propertyDefinition.name] &&
+                                      touched[propertyDefinition.name]
+                                        ? "error"
+                                        : "default"
+                                    }
+                                    propertyChange={handlePropertyChange}
+                                  />
+                                </GridItem>
+                              );
+                            }
+                          )}
+                        </Grid>
+                      </AccordionContent>
+                    </AccordionItem>
+                    <AccordionItem>
+                      <AccordionToggle
+                        onClick={(e) => {
+                          toggle(e, "heartbeat");
+                        }}
+                        isExpanded={expanded.includes("heartbeat")}
+                        id="heartbeat"
+                        className="dbz-c-accordion"
+                      >
+                        Heartbeat properties
+                      </AccordionToggle>
+                      <AccordionContent
+                        id="heartbeat"
+                        isHidden={!expanded.includes("heartbeat")}
+                      >
+                        <Grid hasGutter={true}>
+                          {heartbeatPropertyDefinitions.map(
+                            (propertyDefinition: ConnectorProperty, index) => {
+                              return (
+                                <GridItem
+                                  key={index}
+                                  span={propertyDefinition.gridWidth}
+                                >
+                                  <FormComponent
+                                    propertyDefinition={propertyDefinition}
+                                    propertyChange={handlePropertyChange}
+                                    helperTextInvalid={
+                                      errors[propertyDefinition.name]
+                                    }
+                                    validated={
+                                      errors[propertyDefinition.name] &&
+                                      touched[propertyDefinition.name]
+                                        ? "error"
+                                        : "default"
+                                    }
+                                  />
+                                </GridItem>
+                              );
+                            }
+                          )}
+                        </Grid>
+                      </AccordionContent>
+                    </AccordionItem>
+                  </Accordion>
+                </GridItem>
+              </Grid>
               <FormSubmit
                 ref={ref}
                 setRuntimeOptionsValid={props.setRuntimeOptionsValid}

--- a/ui/packages/ui/src/app/shared/Utils.ts
+++ b/ui/packages/ui/src/app/shared/Utils.ts
@@ -274,6 +274,56 @@ export function minimizePropertyValues (propertyValues: Map<string, string>, pro
   return minimizedValues;
 }
 
+/**
+ * Apply optional grid formatting values to some properties for better layouts.
+ * @param propertyDefns the array of property definitions
+ */
+export function getGridFormattedProperties (propertyDefns: ConnectorProperty[]): ConnectorProperty[] {
+  const formattedPropertyDefns: ConnectorProperty[] = [...propertyDefns];
+
+  for (const propDefn of formattedPropertyDefns) {
+    switch (propDefn.name) {
+      case PropertyName.DATABASE_PORT:
+      case PropertyName.SNAPSHOT_DELAY_MS:
+      case PropertyName.SNAPSHOT_FETCH_SIZE:
+      case PropertyName.SNAPSHOT_LOCK_TIMEOUT_MS:
+      case PropertyName.BINARY_HANDLING_MODE:
+      case PropertyName.DECIMAL_HANDLING_MODE:
+      case PropertyName.HSTORE_HANDLING_MODE:
+      case PropertyName.INTERVAL_HANDLING_MODE:
+      case PropertyName.TIME_PRECISION_MODE:
+      case PropertyName.EVENT_PROCESSING_FAILURE_HANDLING_MODE:
+      case PropertyName.MAX_QUEUE_SIZE:
+      case PropertyName.MAX_BATCH_SIZE:
+      case PropertyName.POLL_INTERVAL_MS:
+      case PropertyName.RETRIABLE_RESTART_CONNECTOR_WAIT_MS:
+      case PropertyName.HEARTBEAT_INTERVAL_MS:
+      case PropertyName.PLUGIN_NAME:
+      case PropertyName.PUBLICATION_AUTOCREATE_MODE:
+      case PropertyName.SCHEMA_REFRESH_MODE:
+        propDefn.gridWidth = 4;
+        break;
+      case PropertyName.SLOT_MAX_RETRIES:
+      case PropertyName.SLOT_RETRY_DELAY_MS:
+      case PropertyName.STATUS_UPDATE_INTERVAL_MS:
+      case PropertyName.XMIN_FETCH_INTERVAL_MS:
+        propDefn.gridWidth = 6;
+        break;
+      case PropertyName.DATABASE_HOSTNAME:
+        propDefn.gridWidth = 8;
+        break;
+      case PropertyName.SNAPSHOT_MODE:
+        propDefn.gridWidth = 9;
+        break;
+      default:
+        propDefn.gridWidth = 12;
+        break;
+    }
+  }
+ 
+  return formattedPropertyDefns;
+}
+
 export function mapToObject(inputMap: Map<string, string>) {
   const obj = {};
   inputMap.forEach((value, key) => {


### PR DESCRIPTION
Improved layout of properties by shortening some input components similar to mockup layouts
- added optional attribute 'gridWidth' to ConnectorProperty
- added function in Utils to set the gridWidth attribute on incoming properties
- wrapped the Accordion components to shorten overall form input widths to 75% of available space
- property gridWidth attributes are then used in the form grids to display appropriate width elements
- also improved the filter popover text and added a link to regex information