### PR TITLE
Adapt to connector list response from service

### DIFF
--- a/ui/packages/models/src/ui.model.ts
+++ b/ui/packages/models/src/ui.model.ts
@@ -15,15 +15,15 @@
  * limitations under the License.
  */
 
-
 /**
  * Model which represents a connector
  */
 // tslint:disable-next-line: interface-name
 export interface Connector {
+    connectorStatus: 'UNASSIGNED' | 'RUNNING' | 'PAUSED' | 'FAILED' | 'DESTROYED';
+    connectorType: string;
     name: string;
-    description: string;
-    type: string;
+    taskStates: any;
 }
 
 /**

--- a/ui/packages/services/src/connector/connector.service.ts
+++ b/ui/packages/services/src/connector/connector.service.ts
@@ -16,7 +16,7 @@
  */
 
 import {
-    ConnectionValidationResult, FilterValidationResult, PropertiesValidationResult, ConnectorConfiguration
+    Connector, ConnectionValidationResult, FilterValidationResult, PropertiesValidationResult
 } from "@debezium/ui-models";
 import {BaseService} from "../baseService";
 
@@ -109,6 +109,16 @@ export class ConnectorService extends BaseService {
 
         const endpoint: string = this.endpoint("/connector/:clusterId/:connectorTypeId", { clusterId, connectorTypeId });
         return this.httpPostWithReturn(endpoint, body);
+    }
+
+    /**
+     * Get the available connectors for the supplied clusterId
+     */
+    public getConnectors(clusterId: number): Promise<Connector[]> {
+        this.logger.info("[ConnectorService] Getting the list of connectors.");
+
+        const endpoint: string = this.endpoint("/connectors/:clusterId", { clusterId });
+        return this.httpGet<Connector[]>(endpoint);
     }
 
 }

--- a/ui/packages/ui/src/app/pages/connectors/ConnectorListItem.tsx
+++ b/ui/packages/ui/src/app/pages/connectors/ConnectorListItem.tsx
@@ -14,11 +14,13 @@ import {
   ConfirmationIconType,
 } from "src/app/shared";
 import { ConnectorIcon } from "./ConnectorIcon";
+import { ConnectorStatus } from './ConnectorStatus';
 
 export interface IConnectorListItemProps {
-  connectorDescription?: string;
-  connectorName: string;
-  connectorType: string;
+  name: string;
+  status: string;
+  taskStates: string[]
+  type: string;
 }
 
 export const ConnectorListItem: React.FunctionComponent<IConnectorListItemProps> = (
@@ -34,7 +36,7 @@ export const ConnectorListItem: React.FunctionComponent<IConnectorListItemProps>
     setShowDeleteDialog(false);
 
     // TODO: do the delete via the rest call
-    alert("Do the delete!");
+    alert("Not yet implemented: delete the connector.");
   };
 
   const showConfirmationDialog = () => {
@@ -59,28 +61,34 @@ export const ConnectorListItem: React.FunctionComponent<IConnectorListItemProps>
       <DataListItem
         aria-labelledby={"connector list item"}
         className={"connector-list-item"}
-        data-testid={`connector-list-item-${props.connectorName}`}
+        data-testid={`connector-list-item-${props.name}`}
       >
         <DataListItemRow>
           <DataListItemCells
             dataListCells={[
               <DataListCell key={0} width={1}>
                 <ConnectorIcon
-                  connectorType={props.connectorType}
-                  alt={props.connectorName}
+                  connectorType={props.type}
+                  alt={props.name}
                   width={50}
                   height={50}
                 />
               </DataListCell>,
-              <DataListCell key={"primary content"} width={5}>
+              <DataListCell key={1} width={2}>
                 <div>
-                  <b data-testid={"connector-name"}>{props.connectorName}</b>
-                  <br />
-                  <span data-testid={"connector-description"}>
-                    {props.connectorDescription
-                      ? props.connectorDescription
-                      : ""}
-                  </span>
+                  <b data-testid={"connector-name"}>{props.name}</b>
+                </div>
+              </DataListCell>,
+              <DataListCell key={2} width={1}>
+                <div>
+                  <ConnectorStatus
+                    currentStatus={props.status}
+                  />
+                </div>
+              </DataListCell>,
+              <DataListCell key={3} width={1}>
+                <div>
+                  Tasks: {props.taskStates.join(', ')}
                 </div>
               </DataListCell>,
             ]}

--- a/ui/packages/ui/src/app/pages/connectors/ConnectorStatus.tsx
+++ b/ui/packages/ui/src/app/pages/connectors/ConnectorStatus.tsx
@@ -1,0 +1,39 @@
+import { Label } from "@patternfly/react-core";
+import * as React from "react";
+import { ConnectorState } from "src/app/shared";
+  
+  export interface IConnectorStatusProps {
+    currentStatus: string;
+  }
+
+  /**
+   * Component for display of Connector Status
+   */
+  export const ConnectorStatus: React.FunctionComponent<IConnectorStatusProps> = (
+    props
+  ) => {
+
+    let color: "grey" | "green" | "red" | "orange" = "grey";
+    switch (props.currentStatus) {
+      case ConnectorState.DESTROYED:
+      case ConnectorState.FAILED:
+        color = "red";
+        break;
+      case ConnectorState.RUNNING:
+        color = "green";
+        break;
+      case ConnectorState.PAUSED:
+        color = "orange";
+        break;
+      case ConnectorState.UNASSIGNED:
+        color = "grey";
+        break;
+    }
+    
+    return (
+      <Label data-testid={"connector-status-label"} color={color}>
+        {props.currentStatus}
+      </Label>
+    );
+};
+  

--- a/ui/packages/ui/src/app/pages/connectors/ConnectorsPage.tsx
+++ b/ui/packages/ui/src/app/pages/connectors/ConnectorsPage.tsx
@@ -36,10 +36,15 @@ function getSortedConnectors(connectors: Connector[]) {
 export const ConnectorsPage: React.FunctionComponent = () => {
   // TODO: Replace this fake data with results from rest service call, when available.
   const [connectors, setConnectors] = React.useState<Connector[]>([
+    // UNCOMMENT THIS TO SEE SAMPLE CONNECTOR IN LIST
     // {
     //   name: "postgresTest",
-    //   description: "PostgreSQL connector",
-    //   type: ConnectorTypeId.POSTGRES
+    //   connectorStatus: "PAUSED",
+    //   connectorType: ConnectorTypeId.POSTGRES,
+    //   taskStates: {
+    //     "0" : "RUNNING",
+    //     "1" : "PAUSED"
+    //   }
     // } as Connector,
   ] as Connector[]);
   const [connectCluster, setConnectCluster] = React.useState<string>("");
@@ -82,6 +87,19 @@ export const ConnectorsPage: React.FunctionComponent = () => {
       });
   }, [setConnectClusters]);
 
+  // React.useEffect(() => {
+  //   const connectorService = Services.getConnectorService();
+  //   fetch_retry(connectorService.getConnectors, connectorService)
+  //     .then((connectors: Connector[]) => {
+  //       setLoading(false);
+  //       setConnectors([...connectors]);
+  //     })
+  //     .catch((err: React.SetStateAction<Error>) => {
+  //       setApiError(true);
+  //       setErrorMsg(err);
+  //     });
+  // }, [setConnectors]);
+
   return (
     <WithLoader
       error={apiError}
@@ -120,9 +138,10 @@ export const ConnectorsPage: React.FunctionComponent = () => {
                   return (
                     <ConnectorListItem
                       key={index}
-                      connectorName={conn.name}
-                      connectorType={conn.type}
-                      connectorDescription={conn.description}
+                      name={conn.name}
+                      type={conn.connectorType}
+                      status={conn.connectorStatus}
+                      taskStates={['RUNNING', 'PAUSED']}
                     />
                   );
                 })}

--- a/ui/packages/ui/src/app/shared/Utils.ts
+++ b/ui/packages/ui/src/app/shared/Utils.ts
@@ -1,5 +1,13 @@
 import { ConnectorProperty, ConnectorType } from "@debezium/ui-models";
 
+export enum ConnectorState {
+  UNASSIGNED = "UNASSIGNED",
+  RUNNING = "RUNNING",
+  PAUSED = "PAUSED",
+  FAILED = "FAILED",
+  DESTROYED = "DESTROYED"
+}
+
 export enum ConnectorTypeId {
   POSTGRES = "postgres",
   MYSQL = "mysql",


### PR DESCRIPTION
Some initial work to adapt the UI to the actual connector list from the backend service
- updated Connector model object in the UI
- created function in connector service to get the connector list
- adapted ConnectorListItem for display of the connector attributes
- created ConnectorStatus component for display of the connector status as a label with varying colors
- included the fetch in the ConnectorsPage, but it is still commented out until the backend code is merged.
- 'taskStates' just temp data for now - it will need to be hooked up.
