### PR TITLE
Connector list page work for fetch of connectors list

### DIFF
--- a/ui/packages/ui/src/app/Layout/AppLayout.tsx
+++ b/ui/packages/ui/src/app/Layout/AppLayout.tsx
@@ -11,7 +11,7 @@ import './layout.css';
 
 const AppLayout: React.FC = ({ children }) => {
 	const [breadcrumb, setHasBreadcrumb] = React.useState(null);
-	const [cluster, setCluster] = React.useState<string>("");
+	const [clusterId, setClusterId] = React.useState<number>(1);
 	const showBreadcrumb = (b: any) => setHasBreadcrumb(b);
 
 	const PageSkipToContent = (
@@ -19,14 +19,14 @@ const AppLayout: React.FC = ({ children }) => {
 			Skip to Content
 		</SkipToContent>
 	);
-	const handleClusterChange = (value: string, event: any) => {
-		setCluster(value)
+	const handleClusterIdChange = (id: number) => {
+		setClusterId(id);
 	}
 	return (
 
-		<AppLayoutContext.Provider value={{ showBreadcrumb, cluster }}>
+		<AppLayoutContext.Provider value={{ showBreadcrumb, clusterId }}>
 			<Page
-				header={<AppHeader handleChange={handleClusterChange} />}
+				header={<AppHeader handleClusterChange={handleClusterIdChange} />}
 				skipToContent={PageSkipToContent}
 				breadcrumb={breadcrumb}
 				className="app-page"

--- a/ui/packages/ui/src/app/Layout/AppLayoutContext.tsx
+++ b/ui/packages/ui/src/app/Layout/AppLayoutContext.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 export interface IAppLayoutContext {
   showBreadcrumb: (breadcrumb: any) => void;
   handleClusterChange: (value: string, event: any) => void;
-  cluster: any;
+  clusterId: number;
 }
 
 export const AppLayoutContextDefaultValue = {} as IAppLayoutContext;

--- a/ui/packages/ui/src/app/Layout/appHeader.tsx
+++ b/ui/packages/ui/src/app/Layout/appHeader.tsx
@@ -8,7 +8,7 @@ import BrandLogo from '../../../assets/images/debezium_logo_300px.png';
 import { KafkaConnectCluster } from '../components';
 
 export interface IAppHeader {
-	handleChange: (value: string, event: any) => void;
+	handleClusterChange: (clusterId: number) => void;
 }
 
 const AppHeader: React.FC<IAppHeader> = (props) => {
@@ -20,7 +20,7 @@ const AppHeader: React.FC<IAppHeader> = (props) => {
 
 	const headerTools = (
 		<>
-			<KafkaConnectCluster handleChange={props.handleChange} />
+			<KafkaConnectCluster handleChange={props.handleClusterChange} />
 		</>
 	);
 

--- a/ui/packages/ui/src/app/components/KafkaConnectCluster.tsx
+++ b/ui/packages/ui/src/app/components/KafkaConnectCluster.tsx
@@ -5,11 +5,17 @@ import { fetch_retry } from "src/app/shared";
 import { BasicSelectInput } from '../components';
 
 export interface IKafkaConnectCluster {
-  handleChange: (value: string, event: any) => void;
+  handleChange: (clusterId: number) => void;
 }
+
 export const KafkaConnectCluster: React.FC<IKafkaConnectCluster> = (props) => {
 
   const [connectClusters, setConnectClusters] = React.useState<string[]>([""]);
+
+  const handleClusterChange = (value: string, event: any) => {
+    const index = connectClusters.indexOf(value) + 1
+    props.handleChange(index);
+  }
   
   React.useEffect(() => {
     const globalsService = Services.getGlobalsService();
@@ -30,7 +36,7 @@ export const KafkaConnectCluster: React.FC<IKafkaConnectCluster> = (props) => {
             options={connectClusters}
             label="Kafka connect cluster"
             fieldId="kafka-connect-cluster"
-            propertyChange={props.handleChange}
+            propertyChange={handleClusterChange}
           />
         </Form>
       </div>

--- a/ui/packages/ui/src/app/pages/connectors/ConnectorListItem.tsx
+++ b/ui/packages/ui/src/app/pages/connectors/ConnectorListItem.tsx
@@ -12,6 +12,7 @@ import {
   ConfirmationButtonStyle,
   ConfirmationDialog,
   ConfirmationIconType,
+  ConnectorTypeId,
 } from "src/app/shared";
 import { ConnectorIcon } from "./ConnectorIcon";
 import { ConnectorStatus } from './ConnectorStatus';
@@ -19,7 +20,7 @@ import { ConnectorStatus } from './ConnectorStatus';
 export interface IConnectorListItemProps {
   name: string;
   status: string;
-  taskStates: string[]
+  taskStates: any
   type: string;
 }
 
@@ -36,12 +37,17 @@ export const ConnectorListItem: React.FunctionComponent<IConnectorListItemProps>
     setShowDeleteDialog(false);
 
     // TODO: do the delete via the rest call
-    alert("Not yet implemented: delete the connector.");
+    alert("Sorry, delete is not yet implemented.");
   };
 
   const showConfirmationDialog = () => {
     setShowDeleteDialog(true);
   };
+
+  const getTaskStateStr = (taskStates: any) => {
+    const stateMap = new Map(Object.entries(taskStates));
+    return Array.from(stateMap.values()).join(", ");
+  }
 
   return (
     <>
@@ -68,7 +74,7 @@ export const ConnectorListItem: React.FunctionComponent<IConnectorListItemProps>
             dataListCells={[
               <DataListCell key={0} width={1}>
                 <ConnectorIcon
-                  connectorType={props.type}
+                  connectorType={props.type === "PostgreSQL" ? ConnectorTypeId.POSTGRES : props.type}
                   alt={props.name}
                   width={50}
                   height={50}
@@ -88,7 +94,7 @@ export const ConnectorListItem: React.FunctionComponent<IConnectorListItemProps>
               </DataListCell>,
               <DataListCell key={3} width={1}>
                 <div>
-                  Tasks: {props.taskStates.join(', ')}
+                  Tasks: {getTaskStateStr(props.taskStates)}
                 </div>
               </DataListCell>,
             ]}


### PR DESCRIPTION
Additional work on the connector list page and connector items
- modify kafka connect cluster component to pass the clusterId on change.  This allows the ConnectorsPage to get the id directly from the context instead of fetching the connectors again to determine the id.
- remove call from ConnectorsPage to get clusters - no longer needed
- fix the fetch of the connectors list
- passing actual task state to ConnectorListItem (was hardcoded)
- adapt ConnectorListItem to recognize alternate PostgreSQL type name.
