### PR TITLE
Making backend base URL configurable

### DIFF
--- a/backend/src/main/java/io/debezium/configserver/rest/FrontendConfigResource.java
+++ b/backend/src/main/java/io/debezium/configserver/rest/FrontendConfigResource.java
@@ -1,0 +1,30 @@
+package io.debezium.configserver.rest;
+
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import java.net.URI;
+
+@Path("")
+public class FrontendConfigResource {
+
+    public static final String PROPERTY_BASE_URI = "ui.base.uri";
+    public static final String FRONTEND_CONFIG_ENDPOINT = "/config.js";
+    public static final String DEFAULT_BASE_URI = "http://localhost:8080";
+
+    @ConfigProperty(name = PROPERTY_BASE_URI, defaultValue = DEFAULT_BASE_URI)
+    URI UiBaseURI;
+
+    @Path(FRONTEND_CONFIG_ENDPOINT)
+    @GET
+    @Produces("application/javascript")
+    public String getFrontendConfig() {
+        return "window.DEFAULT_CONFIG={" +
+                "artifacts:{"
+                + "type:\"rest\",url:\"" + UiBaseURI + ConnectorResource.API_PREFIX + "/\"" +
+                "},features:{readOnly:false},mode:\"prod\"};";
+    }
+
+}

--- a/backend/src/main/java/io/debezium/configserver/rest/FrontendConfigResource.java
+++ b/backend/src/main/java/io/debezium/configserver/rest/FrontendConfigResource.java
@@ -11,20 +11,22 @@ import java.net.URI;
 public class FrontendConfigResource {
 
     public static final String PROPERTY_BASE_URI = "ui.base.uri";
+    public static final String PROPERTY_UI_MODE = "ui.mode";
     public static final String FRONTEND_CONFIG_ENDPOINT = "/config.js";
-    public static final String DEFAULT_BASE_URI = "http://localhost:8080";
+    public static final String DEFAULT_BASE_URI = "http://localhost:8080/api";
+    public static final String DEFAULT_UI_MODE = "dev";
 
     @ConfigProperty(name = PROPERTY_BASE_URI, defaultValue = DEFAULT_BASE_URI)
-    URI UiBaseURI;
+    URI UIBaseURI;
+
+    @ConfigProperty(name = PROPERTY_UI_MODE, defaultValue = DEFAULT_UI_MODE)
+    String UIMode;
 
     @Path(FRONTEND_CONFIG_ENDPOINT)
     @GET
     @Produces("application/javascript")
     public String getFrontendConfig() {
-        return "window.DEFAULT_CONFIG={" +
-                "artifacts:{"
-                + "type:\"rest\",url:\"" + UiBaseURI + ConnectorResource.API_PREFIX + "/\"" +
-                "},features:{readOnly:false},mode:\"prod\"};";
+        return "window.UI_BASE_URI=\"" + UIBaseURI + "\"; window.UI_MODE=\"" + UIMode + "\";";
     }
 
 }

--- a/ui/packages/services/src/config/config.service.ts
+++ b/ui/packages/services/src/config/config.service.ts
@@ -42,21 +42,15 @@ export class ConfigService implements Service {
 
     constructor() {
         const w: any = window;
-        if (w.DEFAULT_CONFIG) {
-            this.config = w.DEFAULT_CONFIG;
-            console.info("[ConfigService] App config found! (using global)");
-        }else{
-            console.error("[ConfigService] App config not found! (using default)");
-            this.config = DEFAULT_CONFIG;
+        this.config = DEFAULT_CONFIG;
+        if (w.UI_BASE_URI) {
+            this.config.artifacts.url = w.UI_BASE_URI;
+            console.info("[ConfigService] Applied UI_BASE_URI (" + this.config.artifacts.url + ")!");
         }
-
-        // if (w.DebeziumUiConfig) {
-        //     this.config = w.DebeziumUiConfig;
-        //     console.info("[ConfigService] Found app config.");
-        // } else {
-        //     console.error("[ConfigService] App config not found! (using default)");
-        //     this.config = window.DEFAULT_CONFIG;
-        // }
+        if (w.UI_MODE) {
+            this.config.mode = w.UI_MODE;
+            console.info("[ConfigService] Applied UI_MODE (" + this.config.mode + ")!");
+        }
     }
 
     public init(): void {

--- a/ui/packages/services/src/config/config.service.ts
+++ b/ui/packages/services/src/config/config.service.ts
@@ -15,8 +15,8 @@
  * limitations under the License.
  */
 
-import {ConfigType, FeaturesConfig} from './config.type';
-import {Service} from "../baseService";
+import { Service } from "../baseService";
+import { ConfigType, FeaturesConfig } from './config.type';
 
 const DEFAULT_CONFIG: ConfigType = {
     artifacts: {
@@ -42,13 +42,21 @@ export class ConfigService implements Service {
 
     constructor() {
         const w: any = window;
-        if (w.DebeziumUiConfig) {
-            this.config = w.DebeziumUiConfig;
-            console.info("[ConfigService] Found app config.");
-        } else {
+        if (w.DEFAULT_CONFIG) {
+            this.config = w.DEFAULT_CONFIG;
+            console.info("[ConfigService] App config found! (using global)");
+        }else{
             console.error("[ConfigService] App config not found! (using default)");
             this.config = DEFAULT_CONFIG;
         }
+
+        // if (w.DebeziumUiConfig) {
+        //     this.config = w.DebeziumUiConfig;
+        //     console.info("[ConfigService] Found app config.");
+        // } else {
+        //     console.error("[ConfigService] App config not found! (using default)");
+        //     this.config = window.DEFAULT_CONFIG;
+        // }
     }
 
     public init(): void {

--- a/ui/packages/ui/src/index.html
+++ b/ui/packages/ui/src/index.html
@@ -8,13 +8,11 @@
 
   <meta id="appName" name="application-name" content="Debezium UI">
   <link rel="icon" type="image/x-icon" href="favicon.ico">
-
+  <script src="config.js"></script>
 </head>
 
 <body>
   <noscript>Enabling JavaScript is required to run this app.</noscript>
   <div id="root"></div>
-  <script src="config.js"></script>
 </body>
-
 </html>

--- a/ui/packages/ui/src/index.html
+++ b/ui/packages/ui/src/index.html
@@ -14,6 +14,7 @@
 <body>
   <noscript>Enabling JavaScript is required to run this app.</noscript>
   <div id="root"></div>
+  <script src="config.js"></script>
 </body>
 
 </html>


### PR DESCRIPTION
Create/Generate `config.js` inside `build` or `dist` folder with the following code snippet and change `url `accordingly.

```
window.DEFAULT_CONFIG = {
  artifacts: {
      type: "rest",
      url: "http://localhost:8080/api/"
  },
  features: {
      readOnly: false
  },
  mode: "dev",
  ui: {
      contextPath: null,
      url: "http://localhost:8888/"
  }
};
```

closes #168 