### PR TITLE
Removing default config from services

### DIFF
--- a/ui/config/config.js
+++ b/ui/config/config.js
@@ -1,5 +1,5 @@
 var DebeziumUiConfig = {
-    mode: "prod",
+    mode: "dev",
     artifacts: {
         type: "rest",
         url: "http://localhost:8080/api"

--- a/ui/config/version.js
+++ b/ui/config/version.js
@@ -1,5 +1,0 @@
-var DebeziumUiInfo = {
-    version: "Debezium UI POC",
-    builtOn: new Date(),
-    url: "http://www.debezium.io/"
-};

--- a/ui/packages/services/src/config/config.service.ts
+++ b/ui/packages/services/src/config/config.service.ts
@@ -17,22 +17,6 @@
 
 import { Service } from "../baseService";
 import { ConfigType, FeaturesConfig } from './config.type';
-
-const DEFAULT_CONFIG: ConfigType = {
-    artifacts: {
-        type: "rest",
-        url: "http://localhost:8080/api/"
-    },
-    features: {
-        readOnly: false
-    },
-    mode: "dev",
-    ui: {
-        contextPath: null,
-        url: "http://localhost:8888/"
-    }
-};
-
 /**
  * A simple configuration service.  Reads information from a global "DebeziumUiConfig" variable
  * that is typically included via JSONP.
@@ -42,7 +26,11 @@ export class ConfigService implements Service {
 
     constructor() {
         const w: any = window;
-        this.config = DEFAULT_CONFIG;
+
+        if (w.DebeziumUiConfig) {
+            this.config = w.DebeziumUiConfig;
+            console.info("[ConfigService] Found app config.");
+        }
         if (w.UI_BASE_URI) {
             this.config.artifacts.url = w.UI_BASE_URI;
             console.info("[ConfigService] Applied UI_BASE_URI (" + this.config.artifacts.url + ")!");

--- a/ui/packages/ui/src/index.html
+++ b/ui/packages/ui/src/index.html
@@ -8,7 +8,8 @@
 
   <meta id="appName" name="application-name" content="Debezium UI">
   <link rel="icon" type="image/x-icon" href="favicon.ico">
-  <script src="config.js"></script>
+  <script type="text/javascript" src="config.js"></script>
+
 </head>
 
 <body>

--- a/ui/packages/ui/webpack.dev.js
+++ b/ui/packages/ui/webpack.dev.js
@@ -1,6 +1,7 @@
 const path = require('path');
 const merge = require("webpack-merge");
 const common = require("./webpack.common.js");
+const CopyWebpackPlugin = require('copy-webpack-plugin');
 
 const HOST = process.env.HOST || "localhost";
 const PORT = process.env.PORT || "8888";
@@ -8,6 +9,9 @@ const PORT = process.env.PORT || "8888";
 module.exports = merge(common, {
   mode: "development",
   devtool: "eval-source-map",
+  plugins: [
+    new CopyWebpackPlugin([{from: '../../config/config.js'}])
+  ],
   output: {
     publicPath: "/"
   },


### PR DESCRIPTION
1. Removing `DEFAULT_CONFIG` from services config.
2. Using `CopyWebpackPlugin` to copy from `/ui/config/config.js` to `dist` 
3. Reading config from global variable (DebeziumUiConfig) directly 