### PR TITLE
Fixing undefined Connector Names from location state 

### DIFF
--- a/ui/packages/ui/src/app/pages/createConnector/CreateConnectorPage.tsx
+++ b/ui/packages/ui/src/app/pages/createConnector/CreateConnectorPage.tsx
@@ -460,6 +460,13 @@ export const CreateConnectorPage: React.FunctionComponent = () => {
   };
 
   React.useEffect(() => {
+    const currentNames = location.state?.connectorNames;
+    if(currentNames === undefined ){
+      history.push('/app')
+    }
+  });
+  
+  React.useEffect(() => {
     const globalsService = Services.getGlobalsService();
     fetch_retry(globalsService.getConnectorTypes, globalsService)
       .then((cTypes: ConnectorType[]) => {


### PR DESCRIPTION
Redirecting create connector page to `/app` if connector names from location state is undefined