### PR TITLE
Utilizing switch component for some properties

### DIFF
--- a/ui/packages/models/src/ui.model.ts
+++ b/ui/packages/models/src/ui.model.ts
@@ -89,7 +89,7 @@ export interface ConnectorProperty {
     gridWidth?: number;
     name: string;
     isMandatory: boolean;
-    type: 'BOOLEAN' | 'STRING' | 'INT' | 'SHORT' | 'LONG' | 'DOUBLE' | 'LIST' | 'CLASS' | 'PASSWORD';
+    type: 'BOOLEAN' | 'BOOLEAN-SWITCH' | 'STRING' | 'INT' | 'SHORT' | 'LONG' | 'DOUBLE' | 'LIST' | 'CLASS' | 'PASSWORD';
 }
 
 /**

--- a/ui/packages/ui/src/app/components/formHelpers/FormComponent.tsx
+++ b/ui/packages/ui/src/app/components/formHelpers/FormComponent.tsx
@@ -3,6 +3,7 @@ import * as React from 'react';
 import { FormCheckboxComponent } from './FormCheckboxComponent';
 import { FormInputComponent } from './FormInputComponent';
 import { FormSelectComponent } from './FormSelectComponent';
+import { FormSwitchComponent } from './FormSwitchComponent';
 
 export interface IFormComponentProps {
   propertyDefinition: ConnectorProperty;
@@ -34,6 +35,17 @@ export const FormComponent: React.FunctionComponent<IFormComponentProps> = (
   } else if (props.propertyDefinition.type === "BOOLEAN") {
     return (
       <FormCheckboxComponent
+        isChecked={typeof props.propertyDefinition.defaultValue !== 'undefined' && props.propertyDefinition.defaultValue === true}
+        label={props.propertyDefinition.displayName}
+        name={props.propertyDefinition.name}
+        propertyChange={props.propertyChange}
+        setFieldValue={props.setFieldValue}
+      />
+    );
+    // Boolean - switch
+  } else if (props.propertyDefinition.type === "BOOLEAN-SWITCH") {
+    return (
+      <FormSwitchComponent
         isChecked={typeof props.propertyDefinition.defaultValue !== 'undefined' && props.propertyDefinition.defaultValue === true}
         label={props.propertyDefinition.displayName}
         name={props.propertyDefinition.name}

--- a/ui/packages/ui/src/app/components/formHelpers/FormSwitchComponent.tsx
+++ b/ui/packages/ui/src/app/components/formHelpers/FormSwitchComponent.tsx
@@ -7,15 +7,16 @@ export interface IFormSwitchComponentProps {
   name: string;
   isChecked: boolean
   propertyChange: (name: string, selection: any) => void;
+  setFieldValue: (field: string, value: any, shouldValidate?: boolean | undefined) => void;
 }
 
 export const FormSwitchComponent: React.FunctionComponent<IFormSwitchComponentProps> = props => {
-  const [isSwitched, setSwitched] = React.useState(true);
+  const [isSwitched, setSwitched] = React.useState(props.isChecked);
   const [field] = useField(props);
   
   const handleChange = (value: boolean) => {
     setSwitched(value);
-    props.propertyChange(field.name, value);
+    props.setFieldValue(field.name, value);
   };
     return (
       <Switch

--- a/ui/packages/ui/src/app/pages/createConnector/CreateConnectorComponent.tsx
+++ b/ui/packages/ui/src/app/pages/createConnector/CreateConnectorComponent.tsx
@@ -24,7 +24,7 @@ import {
   getAdvancedPropertyDefinitions,
   getBasicPropertyDefinitions,
   getDataOptionsPropertyDefinitions,
-  getGridFormattedProperties,
+  getFormattedProperties,
   getRuntimeOptionsPropertyDefinitions,
   isDataOptions,
   isRuntimeOptions,
@@ -541,7 +541,7 @@ export const CreateConnectorComponent: React.FunctionComponent<ICreateConnectorC
     // tslint:disable-next-line: no-unused-expression
     connectorTypes[0]?.properties &&
       setSelectedConnectorPropertyDefns(
-        getGridFormattedProperties(connectorTypes[0]!.properties)
+        getFormattedProperties(connectorTypes[0]!.properties)
       );
 
     // Init the connector property values

--- a/ui/packages/ui/src/app/shared/Utils.ts
+++ b/ui/packages/ui/src/app/shared/Utils.ts
@@ -283,10 +283,13 @@ export function minimizePropertyValues (propertyValues: Map<string, string>, pro
 }
 
 /**
- * Apply optional grid formatting values to some properties for better layouts.
+ * Alter the supplied connector properties for display purposes.
+ * - Apply optional grid formatting values to some properties for better layouts.
+ * - reset type if an alternate component is desired
  * @param propertyDefns the array of property definitions
+ * @returns the array of altered property definitions
  */
-export function getGridFormattedProperties (propertyDefns: ConnectorProperty[]): ConnectorProperty[] {
+export function getFormattedProperties (propertyDefns: ConnectorProperty[]): ConnectorProperty[] {
   const formattedPropertyDefns: ConnectorProperty[] = [...propertyDefns];
 
   for (const propDefn of formattedPropertyDefns) {
@@ -322,6 +325,11 @@ export function getGridFormattedProperties (propertyDefns: ConnectorProperty[]):
         break;
       case PropertyName.SNAPSHOT_MODE:
         propDefn.gridWidth = 9;
+        break;
+      case PropertyName.DATABASE_TCPKEEPALIVE:
+      case PropertyName.SLOT_DROP_ON_STOP:
+        propDefn.gridWidth = 12;
+        propDefn.type = "BOOLEAN-SWITCH";
         break;
       default:
         propDefn.gridWidth = 12;


### PR DESCRIPTION
Addresses issue #220 - UX request to use toggle switch for a couple properties
- add 'BOOLEAN-SWITCH' to ui model to distinguish toggle switch props
- update FormComponent to check for BOOLEAN-SWITCH type
- update Utils.getFormattedProperties to handle the switch properties