### PR TITLE
Adding duration component

### DIFF
--- a/ui/packages/models/src/ui.model.ts
+++ b/ui/packages/models/src/ui.model.ts
@@ -89,7 +89,19 @@ export interface ConnectorProperty {
     gridWidth?: number;
     name: string;
     isMandatory: boolean;
-    type: 'BOOLEAN' | 'BOOLEAN-SWITCH' | 'STRING' | 'INT' | 'SHORT' | 'LONG' | 'DOUBLE' | 'LIST' | 'CLASS' | 'PASSWORD';
+    type: 'BOOLEAN' | 
+          'BOOLEAN-SWITCH' | 
+          'DURATION' | 
+          'STRING' | 
+          'INT' | 
+          'NON-NEG-INT' | 
+          'SHORT' | 
+          'LONG' | 
+          'NON-NEG-LONG' |
+          'DOUBLE' | 
+          'LIST' | 
+          'CLASS' | 
+          'PASSWORD';
 }
 
 /**

--- a/ui/packages/ui/src/app/components/formHelpers/FormCheckboxComponent.css
+++ b/ui/packages/ui/src/app/components/formHelpers/FormCheckboxComponent.css
@@ -1,0 +1,3 @@
+.form-checkbox-component {
+    padding: 7px 0 0 0;
+}

--- a/ui/packages/ui/src/app/components/formHelpers/FormCheckboxComponent.tsx
+++ b/ui/packages/ui/src/app/components/formHelpers/FormCheckboxComponent.tsx
@@ -1,10 +1,13 @@
-import { Checkbox } from '@patternfly/react-core';
+import { Checkbox, Split, SplitItem } from '@patternfly/react-core';
 import { useField } from 'formik';
 import * as React from 'react';
+import "./FormCheckboxComponent.css";
+import { HelpInfoIcon } from './HelpInfoIcon';
 
 export interface IFormCheckboxComponentProps {
   label: string;
   name: string;
+  description: string;
   isChecked: boolean
   propertyChange: (name: string, selection: any) => void;
   setFieldValue: (field: string, value: any, shouldValidate?: boolean | undefined) => void;
@@ -16,13 +19,21 @@ export const FormCheckboxComponent: React.FunctionComponent<IFormCheckboxCompone
     props.setFieldValue(field.name, value);
   };
     return (
-      <Checkbox
-        id={field.name}
-        name={field.name}
-        aria-label={props.label}
-        label={props.label}
-        isChecked={field.value}
-        onChange={handleChange}
-      />
+      <Split>
+        <SplitItem>
+          <Checkbox
+            className="form-checkbox-component"
+            id={field.name}
+            name={field.name}
+            aria-label={props.label}
+            label={props.label}
+            isChecked={field.value}
+            onChange={handleChange}
+          />
+        </SplitItem>
+        <SplitItem>
+          <HelpInfoIcon label={props.label} description={props.description} />
+        </SplitItem>
+      </Split>
     );
 }

--- a/ui/packages/ui/src/app/components/formHelpers/FormComponent.tsx
+++ b/ui/packages/ui/src/app/components/formHelpers/FormComponent.tsx
@@ -1,6 +1,7 @@
 import { ConnectorProperty } from '@debezium/ui-models';
 import * as React from 'react';
 import { FormCheckboxComponent } from './FormCheckboxComponent';
+import { FormDurationComponent } from './FormDurationComponent';
 import { FormInputComponent } from './FormInputComponent';
 import { FormSelectComponent } from './FormSelectComponent';
 import { FormSwitchComponent } from './FormSwitchComponent';
@@ -38,6 +39,7 @@ export const FormComponent: React.FunctionComponent<IFormComponentProps> = (
         isChecked={typeof props.propertyDefinition.defaultValue !== 'undefined' && props.propertyDefinition.defaultValue === true}
         label={props.propertyDefinition.displayName}
         name={props.propertyDefinition.name}
+        description={props.propertyDefinition.description}
         propertyChange={props.propertyChange}
         setFieldValue={props.setFieldValue}
       />
@@ -47,6 +49,21 @@ export const FormComponent: React.FunctionComponent<IFormComponentProps> = (
     return (
       <FormSwitchComponent
         isChecked={typeof props.propertyDefinition.defaultValue !== 'undefined' && props.propertyDefinition.defaultValue === true}
+        label={props.propertyDefinition.displayName}
+        name={props.propertyDefinition.name}
+        description={props.propertyDefinition.description}
+        propertyChange={props.propertyChange}
+        setFieldValue={props.setFieldValue}
+      />
+    );
+    // Duration
+  } else if (props.propertyDefinition.type === "DURATION") {
+    return (
+      <FormDurationComponent
+        description={props.propertyDefinition.description}
+        isRequired={props.propertyDefinition.isMandatory}
+        fieldId={props.propertyDefinition.name}
+        helperTextInvalid={props.helperTextInvalid}
         label={props.propertyDefinition.displayName}
         name={props.propertyDefinition.name}
         propertyChange={props.propertyChange}

--- a/ui/packages/ui/src/app/components/formHelpers/FormDurationComponent.tsx
+++ b/ui/packages/ui/src/app/components/formHelpers/FormDurationComponent.tsx
@@ -1,0 +1,187 @@
+import {
+  FormGroup,
+  Grid,
+  GridItem,
+  InputGroup,
+  Select,
+  SelectOption,
+  SelectVariant,
+  TextInput,
+} from "@patternfly/react-core";
+import { ExclamationCircleIcon } from "@patternfly/react-icons";
+import { useField } from "formik";
+import * as React from "react";
+import { HelpInfoIcon } from "./HelpInfoIcon";
+
+const durationUnitOptions = [
+  <SelectOption key={0} value="Milliseconds" />,
+  <SelectOption key={1} value="Seconds" />,
+  <SelectOption key={2} value="Minutes" />,
+  <SelectOption key={3} value="Hours" />,
+  <SelectOption key={4} value="Days" />,
+];
+
+function getDurationUnitFactor(durationOption: any) {
+  switch (durationOption) {
+    case "Milliseconds":
+      return 1;
+    case "Seconds":
+      return 1000;
+    case "Minutes":
+      return 60000;
+    case "Hours":
+      return 3600000;
+    case "Days":
+      return 86400000;
+    default:
+      return 1;
+  }
+}
+
+// Determines initial units.  Will auto-select the units which result in the lowest int value
+function getInitialDurationUnits(value: any) {
+  if (value === 0) {
+    return "Milliseconds";
+  } else if (value / 86400000 >= 1.0 && Number.isInteger(value / 86400000)) {
+    return "Days";
+  } else if (value / 3600000 >= 1.0 && Number.isInteger(value / 3600000)) {
+    return "Hours";
+  } else if (value / 60000 >= 1.0 && Number.isInteger(value / 60000)) {
+    return "Minutes";
+  } else if (value / 1000 >= 1.0 && Number.isInteger(value / 1000)) {
+    return "Seconds";
+  } else {
+    return "Milliseconds";
+  }
+}
+
+function calculateDuration(durationUnits: any, initialValue: number) {
+  return initialValue / getDurationUnitFactor(durationUnits);
+}
+
+function calculateValue(durationUnits: any, value: number) {
+  return value * getDurationUnitFactor(durationUnits);
+}
+
+export interface IFormDurationComponentProps {
+  label: string;
+  description: string;
+  name: string;
+  fieldId: string;
+  helperTextInvalid?: any;
+  isRequired: boolean;
+  validated?: "default" | "success" | "warning" | "error" | undefined;
+  propertyChange: (name: string, selection: any) => void;
+  setFieldValue: (
+    field: string,
+    value: any,
+    shouldValidate?: boolean | undefined
+  ) => void;
+}
+
+/**
+ * Duration component - allows user to enter a number and corresponding time units
+ * - The duration value is always calculated into milliseconds (required by backend)
+ * - decimals and negative values are not allowed
+ * @param props the component properties
+ */
+export const FormDurationComponent: React.FunctionComponent<IFormDurationComponentProps> = (
+  props
+) => {
+
+  const [field] = useField(props);
+  const initialDurationUnits = getInitialDurationUnits(field.value);
+  const [durationUnits, setDurationUnits] = React.useState(
+    initialDurationUnits
+  );
+  const [isOpen, setIsOpen] = React.useState(false);
+  const handleToggle = () => {
+    setIsOpen(!isOpen);
+  };
+
+  const onSelect = (e: any, selectedDurationUnits: any) => {
+    setIsOpen(false);
+
+    const inputValue = calculateDuration(durationUnits, field.value);
+    setDurationUnits(selectedDurationUnits);
+    props.setFieldValue(
+      field.name,
+      calculateValue(selectedDurationUnits, inputValue),
+      true
+    );
+    props.propertyChange(
+      field.name,
+      calculateValue(selectedDurationUnits, inputValue)
+    );
+  };
+
+  const handleKeyPress = (keyEvent: KeyboardEvent) => {
+    // do not allow entry of '.' or '-'
+    if (keyEvent.key === "." || keyEvent.key === "-") {
+      keyEvent.preventDefault();
+    }
+  };
+
+  const handleTextInputChange = (
+    val: string,
+    event: React.FormEvent<HTMLInputElement>
+  ) => {
+    props.setFieldValue(
+      field.name,
+      calculateValue(durationUnits, parseInt(val, 10)),
+      true
+    );
+  };
+  const handleTextInputBlur = (event: React.ChangeEvent<HTMLInputElement>) => {
+    props.setFieldValue(
+      field.name,
+      calculateValue(durationUnits, event.target.valueAsNumber),
+      true
+    );
+  };
+  const id = field.name;
+
+  return (
+    <FormGroup
+      label={props.label}
+      isRequired={props.isRequired}
+      labelIcon={
+        <HelpInfoIcon label={props.label} description={props.description} />
+      }
+      helperTextInvalid={props.helperTextInvalid}
+      helperTextInvalidIcon={<ExclamationCircleIcon />}
+      fieldId={id}
+      validated={props.validated}
+    >
+      <InputGroup>
+        <Grid>
+          <GridItem span={6}>
+            <TextInput
+              min={"0"}
+              data-testid={id}
+              id={id}
+              type={"number"}
+              defaultValue={`${calculateDuration(durationUnits, field.value)}`}
+              validated={props.validated}
+              onChange={handleTextInputChange}
+              onBlur={handleTextInputBlur}
+              onKeyPress={(event) => handleKeyPress(event as any)}
+            />
+          </GridItem>
+          <GridItem span={6}>
+            <Select
+              variant={SelectVariant.single}
+              aria-label="Select Duration Units"
+              onToggle={handleToggle}
+              onSelect={onSelect}
+              selections={durationUnits}
+              isOpen={isOpen}
+            >
+              {durationUnitOptions}
+            </Select>
+          </GridItem>
+        </Grid>
+      </InputGroup>
+    </FormGroup>
+  );
+};

--- a/ui/packages/ui/src/app/components/formHelpers/FormInputComponent.tsx
+++ b/ui/packages/ui/src/app/components/formHelpers/FormInputComponent.tsx
@@ -20,6 +20,16 @@ export interface IFormInputComponentProps {
 }
 export const FormInputComponent: React.FunctionComponent<IFormInputComponentProps> = props => {
   const [field] = useField(props);
+
+  const handleKeyPress = (keyEvent: KeyboardEvent) => {
+    // disallow entry of "." and "-" for NON-NEG-INT or NON-NEG-LONG
+    // disallow entry of "." for INT or LONG
+    if ( ( (props.type === 'NON-NEG-INT' || props.type === 'NON-NEG-LONG') && (keyEvent.key === "." || keyEvent.key === "-")) ||
+         ( (props.type === 'INT' || props.type === 'LONG') && keyEvent.key === "." ) ) {
+      keyEvent.preventDefault();
+    }
+  };
+
   return (
     <FormGroup
       label={props.label}
@@ -40,12 +50,14 @@ export const FormInputComponent: React.FunctionComponent<IFormInputComponentProp
         aria-label={field.name}
         validated={props.validated}
         type={
-          props.type === "INT" || props.type === "LONG"
+          props.type === "INT" || props.type === "LONG" || props.type === "NON-NEG-INT" || props.type === "NON-NEG-LONG"
             ? "number"
             : props.type === "PASSWORD"
             ? "password"
             : "text"
         }
+        min={ props.type === "NON-NEG-INT" || props.type === "NON-NEG-LONG" ? 0 : undefined }
+        onKeyPress={(event) => handleKeyPress(event as any)}
       />
     </FormGroup>
   );

--- a/ui/packages/ui/src/app/components/formHelpers/FormSwitchComponent.tsx
+++ b/ui/packages/ui/src/app/components/formHelpers/FormSwitchComponent.tsx
@@ -1,9 +1,11 @@
-import { Switch } from '@patternfly/react-core';
+import { Split, SplitItem, Switch } from '@patternfly/react-core';
 import { useField } from 'formik';
 import * as React from 'react';
+import { HelpInfoIcon } from './HelpInfoIcon';
 
 export interface IFormSwitchComponentProps {
   label: string;
+  description: string;
   name: string;
   isChecked: boolean
   propertyChange: (name: string, selection: any) => void;
@@ -17,14 +19,21 @@ export const FormSwitchComponent: React.FunctionComponent<IFormSwitchComponentPr
     props.setFieldValue(field.name, value);
   };
     return (
-      <Switch
-        id={field.name}
-        name={field.name}
-        aria-label={props.label}
-        label={props.label}
-        labelOff={props.label}
-        isChecked={field.value}
-        onChange={handleChange}
-      />
+      <Split>
+        <SplitItem>
+          <Switch
+            id={field.name}
+            name={field.name}
+            aria-label={props.label}
+            label={props.label}
+            labelOff={props.label}
+            isChecked={field.value}
+            onChange={handleChange}
+          />
+        </SplitItem>
+        <SplitItem>
+          <HelpInfoIcon label={props.label} description={props.description} />
+        </SplitItem>
+      </Split>
     );
 }

--- a/ui/packages/ui/src/app/components/formHelpers/index.tsx
+++ b/ui/packages/ui/src/app/components/formHelpers/index.tsx
@@ -1,4 +1,5 @@
 export * from './FormCheckboxComponent'
+export * from './FormDurationComponent'
 export * from './FormInputComponent'
 export * from './FormSelectComponent'
 export * from './FormSwitchComponent'

--- a/ui/packages/ui/src/app/shared/Utils.ts
+++ b/ui/packages/ui/src/app/shared/Utils.ts
@@ -294,31 +294,20 @@ export function getFormattedProperties (propertyDefns: ConnectorProperty[]): Con
 
   for (const propDefn of formattedPropertyDefns) {
     switch (propDefn.name) {
-      case PropertyName.DATABASE_PORT:
-      case PropertyName.SNAPSHOT_DELAY_MS:
-      case PropertyName.SNAPSHOT_FETCH_SIZE:
-      case PropertyName.SNAPSHOT_LOCK_TIMEOUT_MS:
       case PropertyName.BINARY_HANDLING_MODE:
       case PropertyName.DECIMAL_HANDLING_MODE:
       case PropertyName.HSTORE_HANDLING_MODE:
       case PropertyName.INTERVAL_HANDLING_MODE:
       case PropertyName.TIME_PRECISION_MODE:
       case PropertyName.EVENT_PROCESSING_FAILURE_HANDLING_MODE:
-      case PropertyName.MAX_QUEUE_SIZE:
-      case PropertyName.MAX_BATCH_SIZE:
-      case PropertyName.POLL_INTERVAL_MS:
-      case PropertyName.RETRIABLE_RESTART_CONNECTOR_WAIT_MS:
-      case PropertyName.HEARTBEAT_INTERVAL_MS:
       case PropertyName.PLUGIN_NAME:
       case PropertyName.PUBLICATION_AUTOCREATE_MODE:
       case PropertyName.SCHEMA_REFRESH_MODE:
         propDefn.gridWidth = 4;
         break;
       case PropertyName.SLOT_MAX_RETRIES:
-      case PropertyName.SLOT_RETRY_DELAY_MS:
-      case PropertyName.STATUS_UPDATE_INTERVAL_MS:
-      case PropertyName.XMIN_FETCH_INTERVAL_MS:
         propDefn.gridWidth = 6;
+        propDefn.type =  "NON-NEG-INT";
         break;
       case PropertyName.DATABASE_HOSTNAME:
         propDefn.gridWidth = 8;
@@ -331,6 +320,27 @@ export function getFormattedProperties (propertyDefns: ConnectorProperty[]): Con
         propDefn.gridWidth = 12;
         propDefn.type = "BOOLEAN-SWITCH";
         break;
+      case PropertyName.SNAPSHOT_DELAY_MS:
+      case PropertyName.SNAPSHOT_LOCK_TIMEOUT_MS:
+      case PropertyName.RETRIABLE_RESTART_CONNECTOR_WAIT_MS:
+      case PropertyName.HEARTBEAT_INTERVAL_MS:
+      case PropertyName.POLL_INTERVAL_MS:
+        propDefn.gridWidth = 4;
+        propDefn.type = "DURATION";
+        break;
+      case PropertyName.SLOT_RETRY_DELAY_MS:
+      case PropertyName.STATUS_UPDATE_INTERVAL_MS:
+      case PropertyName.XMIN_FETCH_INTERVAL_MS:
+        propDefn.gridWidth = 6;
+        propDefn.type = "DURATION";
+        break;
+      case PropertyName.DATABASE_PORT:
+      case PropertyName.SNAPSHOT_FETCH_SIZE:
+      case PropertyName.MAX_QUEUE_SIZE:
+      case PropertyName.MAX_BATCH_SIZE:
+        propDefn.gridWidth = 4;
+        propDefn.type =  "NON-NEG-INT";
+      break;
       default:
         propDefn.gridWidth = 12;
         break;


### PR DESCRIPTION
Adding a duration component, Issue #126 - and a couple other component improvements.  Some of the properties which utilize the duration component will need to have their titles and descriptions adjusted - I will log a follow-up request for that
- added FormDurationComponent, which allows the user to enter duration values in different units.  Regardless of the selected units, the value is always stored as milliseconds and provided as ms to the backend.
- added a new ConnectorProperty type 'DURATION' to the model and now designating the duration properties in Utils.getFormattedProperties.

Screenshot example of duration component:
![durationComponent](https://user-images.githubusercontent.com/1820403/102128677-d4c65300-3e13-11eb-9261-b16abf38c1f3.png)

- Added HelpInfoIcon to the checkbox and switch components, for display of the property descriptions, similar to other properties
- added new ConnectorProperty types of 'NON-NEG-INT' and 'NON-NEG-LONG' to the model.  This allows the FormInputComponent to disallow negative numbers for those designated properties.  Now designating some of the int properties as such in Utils.getFormattedProperties.  We can now disallow negative values up-front, instead of needing backend validation to see a failure.