### PR TITLE
Fix duration titles, rework table tooltips

### DIFF
--- a/ui/packages/ui/src/app/components/formHelpers/HelpInfoIcon.tsx
+++ b/ui/packages/ui/src/app/components/formHelpers/HelpInfoIcon.tsx
@@ -20,6 +20,7 @@ export const HelpInfoIcon = (props: IHelpInfoIconProps) => {
       bodyContent={<div>{props.description}</div>}
     >
       <button
+        aria-label={`${props.label} Information popover`}
         onClick={e => e.preventDefault()}
         className="pf-c-form__group-label-help"
       >

--- a/ui/packages/ui/src/app/pages/connectors/ConnectorStatus.tsx
+++ b/ui/packages/ui/src/app/pages/connectors/ConnectorStatus.tsx
@@ -1,4 +1,4 @@
-import { Label, Tooltip } from "@patternfly/react-core";
+import { Label } from "@patternfly/react-core";
 import * as React from "react";
 import { ConnectorState } from "src/app/shared";
   
@@ -31,15 +31,9 @@ import { ConnectorState } from "src/app/shared";
     }
     
     return (
-      <Tooltip
-        content={
-        <div>Status: {props.currentStatus}</div>
-        }
-      >
-        <Label data-testid={"connector-status-label"} color={color}>
-          {props.currentStatus}
-        </Label>
-      </Tooltip>
+      <Label data-testid={"connector-status-label"} color={color}>
+        {props.currentStatus}
+      </Label>
     );
 };
   

--- a/ui/packages/ui/src/app/pages/connectors/ConnectorTask.tsx
+++ b/ui/packages/ui/src/app/pages/connectors/ConnectorTask.tsx
@@ -1,5 +1,6 @@
-import { Label, Tooltip } from '@patternfly/react-core';
+import { Label, Split, SplitItem } from '@patternfly/react-core';
 import * as React from "react";
+import { HelpInfoIcon } from 'src/app/components/formHelpers/HelpInfoIcon';
 import { ConnectorState } from "src/app/shared";
 import "./ConnectorsTableComponent.css";
 
@@ -39,27 +40,25 @@ export const ConnectorTask: React.FunctionComponent<IConnectorTaskProps> = (
 
   return (
     <>
-      <Tooltip
-        content={
-          <div>
+      <Split>
+        <SplitItem>
+          <Label
+            className="status-indicator"
+            color={color}
+            data-testid={"connector-status-div"}
+          >
             Task {props.taskId}: {props.task}
-            <div className="errors">
-              {errors.map((errormsg, key) => {
-                  return <div className="error" key={key}>{errormsg}</div>;
-                })
-              }
-            </div>
-          </div>
-        }
-      >
-        <Label
-          className="status-indicator"
-          color={color}
-          data-testid={"connector-status-div"}
-        >
-          Task {props.taskId}: {props.task}
-        </Label>
-      </Tooltip>
+          </Label>
+        </SplitItem>
+        {errors && errors.length > 0 ? (
+          <SplitItem>
+            <HelpInfoIcon
+              label={"Task Status"}
+              description={errors.join(":")}
+            />
+          </SplitItem>
+        ) : null}
+      </Split>
     </>
   );
 };

--- a/ui/packages/ui/src/app/pages/connectors/ConnectorsTableComponent.tsx
+++ b/ui/packages/ui/src/app/pages/connectors/ConnectorsTableComponent.tsx
@@ -110,7 +110,7 @@ export const ConnectorsTableComponent: React.FunctionComponent<IConnectorsTableC
       taskElements.push(
         <ConnectorTask
           key={id}
-          task={taskState.taskStatus}
+          task={taskState}
           taskId={id}
           errors={taskState.errors}
         />

--- a/ui/packages/ui/src/app/shared/Utils.ts
+++ b/ui/packages/ui/src/app/shared/Utils.ts
@@ -327,12 +327,14 @@ export function getFormattedProperties (propertyDefns: ConnectorProperty[]): Con
       case PropertyName.POLL_INTERVAL_MS:
         propDefn.gridWidth = 4;
         propDefn.type = "DURATION";
+        propDefn.displayName = propDefn.displayName.replace("(ms)", "").replace("(milli-seconds)","").replace("(milliseconds)","");
         break;
       case PropertyName.SLOT_RETRY_DELAY_MS:
       case PropertyName.STATUS_UPDATE_INTERVAL_MS:
       case PropertyName.XMIN_FETCH_INTERVAL_MS:
         propDefn.gridWidth = 6;
         propDefn.type = "DURATION";
+        propDefn.displayName = propDefn.displayName.replace("(ms)", "");
         break;
       case PropertyName.DATABASE_PORT:
       case PropertyName.SNAPSHOT_FETCH_SIZE:


### PR DESCRIPTION
- remove units from duration form component titles.  The user can select different units, so the titles were confusing
- remove tooltips from ConnectorStatus in the table - the tooltip didn't provide any additional info
- in ConnectorTask, changed tooltip to popover.  The popover icon will only show up if there are additional errors to display.
- added aria-label to the HelpInfoIcon.  Should help with accessibility for the help popovers