### PR TITLE
Adjustments to TaskStatus

### DIFF
--- a/ui/packages/ui/src/app/components/formHelpers/HelpInfoIcon.tsx
+++ b/ui/packages/ui/src/app/components/formHelpers/HelpInfoIcon.tsx
@@ -6,7 +6,7 @@ import React from 'react';
 
 export interface IHelpInfoIconProps {
   label: string,
-  description: string,
+  description: string | JSX.Element,
 }
 
 export const HelpInfoIcon = (props: IHelpInfoIconProps) => {

--- a/ui/packages/ui/src/app/pages/connectors/ConnectorTask.css
+++ b/ui/packages/ui/src/app/pages/connectors/ConnectorTask.css
@@ -1,0 +1,4 @@
+.connector-task-error{
+  padding-bottom: 5px;
+}
+  

--- a/ui/packages/ui/src/app/pages/connectors/ConnectorTask.tsx
+++ b/ui/packages/ui/src/app/pages/connectors/ConnectorTask.tsx
@@ -2,12 +2,12 @@ import { Label, Split, SplitItem } from '@patternfly/react-core';
 import * as React from "react";
 import { HelpInfoIcon } from 'src/app/components/formHelpers/HelpInfoIcon';
 import { ConnectorState } from "src/app/shared";
-import "./ConnectorsTableComponent.css";
+import "./ConnectorTask.css";
 
 export interface IConnectorTaskProps {
-  task: string;
+  status: string;
   taskId: string;
-  errors: any;
+  errors?: any;
 }
 
 /**
@@ -17,7 +17,7 @@ export const ConnectorTask: React.FunctionComponent<IConnectorTaskProps> = (
   props
 ) => {
   let color: "grey" | "green" | "red" | "orange" = "grey";
-  switch (props.task) {
+  switch (props.status) {
     case ConnectorState.DESTROYED:
     case ConnectorState.FAILED:
       color = "red";
@@ -33,9 +33,11 @@ export const ConnectorTask: React.FunctionComponent<IConnectorTaskProps> = (
       break;
   }
 
-  let errors = [];
+  const errors: JSX.Element[] = [];
   if (props.errors) {
-    errors =  props.errors;
+    props.errors.forEach( (error: string) => {
+      errors.push(<div className="connector-task-error">{error}</div>)
+    });
   }
 
   return (
@@ -47,14 +49,14 @@ export const ConnectorTask: React.FunctionComponent<IConnectorTaskProps> = (
             color={color}
             data-testid={"connector-status-div"}
           >
-            Task {props.taskId}: {props.task}
+            Task {props.taskId}: {props.status}
           </Label>
         </SplitItem>
         {errors && errors.length > 0 ? (
           <SplitItem>
             <HelpInfoIcon
-              label={"Task Status"}
-              description={errors.join(":")}
+              label={"Task Status Detail"}
+              description={<div>{errors}</div>}
             />
           </SplitItem>
         ) : null}

--- a/ui/packages/ui/src/app/pages/connectors/ConnectorsTableComponent.tsx
+++ b/ui/packages/ui/src/app/pages/connectors/ConnectorsTableComponent.tsx
@@ -110,7 +110,7 @@ export const ConnectorsTableComponent: React.FunctionComponent<IConnectorsTableC
       taskElements.push(
         <ConnectorTask
           key={id}
-          task={taskState.taskStatus}
+          status={taskState.taskStatus}
           taskId={id}
           errors={taskState.errors}
         />


### PR DESCRIPTION
Changes to allow better formatting of the task errors
- allow element in HelpInfoIcon
- changes in ConnectorTask to better format the errors

![TaskStatus](https://user-images.githubusercontent.com/1820403/102400305-5ac6d300-3fa7-11eb-8f1f-22f987fa5391.png)
