### PR TITLE
Adding component for hash-salt masking

### DIFF
--- a/ui/packages/models/src/ui.model.ts
+++ b/ui/packages/models/src/ui.model.ts
@@ -102,7 +102,8 @@ export interface ConnectorProperty {
           'LIST' | 
           'CLASS' | 
           'PASSWORD'|
-          'FRAGMENT';
+          'COL_MASK_OR_TRUNCATE' |
+          'COL_MASK_HASH_SALT';
 }
 
 /**

--- a/ui/packages/ui/src/app/components/formHelpers/FormComponent.tsx
+++ b/ui/packages/ui/src/app/components/formHelpers/FormComponent.tsx
@@ -3,6 +3,7 @@ import * as React from 'react';
 import { FormCheckboxComponent } from './FormCheckboxComponent';
 import { FormDurationComponent } from './FormDurationComponent';
 import { FormInputComponent } from './FormInputComponent';
+import { FormMaskHashSaltComponent } from './FormMaskHashSaltComponent';
 import { FormMaskOrTruncateComponent } from './FormMaskOrTruncateComponent';
 import { FormSelectComponent } from './FormSelectComponent';
 import { FormSwitchComponent } from './FormSwitchComponent';
@@ -71,8 +72,8 @@ export const FormComponent: React.FunctionComponent<IFormComponentProps> = (
         setFieldValue={props.setFieldValue}
       />
     );
-     // FRAGMENT
-  } else if (props.propertyDefinition.type === "FRAGMENT") {
+     // Column Mask or Column Truncate
+  } else if (props.propertyDefinition.type === "COL_MASK_OR_TRUNCATE") {
     return (
       <FormMaskOrTruncateComponent
         description={props.propertyDefinition.description}
@@ -85,7 +86,21 @@ export const FormComponent: React.FunctionComponent<IFormComponentProps> = (
         setFieldValue={props.setFieldValue}
       />
     );
-    
+     // Column Mask Hash and Salt
+  } else if (props.propertyDefinition.type === "COL_MASK_HASH_SALT") {
+    return (
+      <FormMaskHashSaltComponent
+        description={props.propertyDefinition.description}
+        isRequired={props.propertyDefinition.isMandatory}
+        fieldId={props.propertyDefinition.name}
+        helperTextInvalid={props.helperTextInvalid}
+        label={props.propertyDefinition.displayName}
+        name={props.propertyDefinition.name}
+        propertyChange={props.propertyChange}
+        setFieldValue={props.setFieldValue}
+      />
+    );
+        
    // Any other - Text input
   }  else {
     return (

--- a/ui/packages/ui/src/app/components/formHelpers/FormMaskHashSaltComponent.css
+++ b/ui/packages/ui/src/app/components/formHelpers/FormMaskHashSaltComponent.css
@@ -1,0 +1,8 @@
+.form-mask-hash-salt-component{
+    &-column{
+        margin-right: 20px;
+        &-input{
+            flex-grow:1;
+        }
+    }
+}

--- a/ui/packages/ui/src/app/components/formHelpers/FormMaskHashSaltComponent.tsx
+++ b/ui/packages/ui/src/app/components/formHelpers/FormMaskHashSaltComponent.tsx
@@ -1,0 +1,180 @@
+import {
+  Flex,
+  FlexItem,
+  FormGroup,
+  Grid,
+  GridItem,
+  InputGroup,
+  TextInput,
+} from "@patternfly/react-core";
+import { ExclamationCircleIcon } from "@patternfly/react-icons";
+import { useField } from "formik";
+import * as React from "react";
+import "./FormMaskHashSaltComponent.css";
+import { HelpInfoIcon } from "./HelpInfoIcon";
+
+export interface IFormMaskHashSaltComponentProps {
+  label: string;
+  description: string;
+  name: string;
+  fieldId: string;
+  helperTextInvalid?: any;
+  isRequired: boolean;
+  validated?: "default" | "success" | "warning" | "error" | undefined;
+  propertyChange: (name: string, selection: any) => void;
+  setFieldValue: (
+    field: string,
+    value: any,
+    shouldValidate?: boolean | undefined
+  ) => void;
+}
+
+export const FormMaskHashSaltComponent: React.FunctionComponent<IFormMaskHashSaltComponentProps> = (
+  props
+) => {
+  const [field] = useField(props);
+
+  /**
+   * Return column segment from the supplied string
+   * Format of string : columns&&hash||salt
+   *   columns - first segment, ended with '&&'
+   *   hash    - second segment, preceeded by '&&' and ended with '||'
+   *   salt    - third segment, preceeded by '||'
+   * @param val the 3 segment string
+   */
+  const getColsValue = (val: string) => {
+    if (val && val.includes("&&")) {
+      return val.split("&&")[0];
+    }
+    return "";
+  };
+
+  /**
+   * Return hash segment from the supplied string
+   * Format of string : columns&&hash||salt
+   *   columns - first segment, ended with '&&'
+   *   hash    - second segment, preceeded by '&&' and ended with '||'
+   *   salt    - third segment, preceeded by '||'
+   * @param val the 3 segment string
+   */
+  const getHashValue = (val: string) => {
+    if (val && val.includes("&&")) {
+      if (val.split("&&")[1]) {
+        return val.split("&&")[1].split("||")[0];
+      }
+      return "";
+    }
+    return "";
+  };
+
+  /**
+   * Return salt segment from the supplied string
+   * Format of string : columns&&hash||salt
+   *   columns - first segment, ended with '&&'
+   *   hash    - second segment, preceeded by '&&' and ended with '||'
+   *   salt    - third segment, preceeded by '||'
+   * @param val the 3 segment string
+   */
+  const getSaltValue = (val: string) => {
+    if (val && val.includes("&&")) {
+      if (val.split("&&")[1]) {
+        const trailing = val.split("&&")[1].split("||");
+        return trailing[1] ? trailing[1] : "";
+      }
+      return "";
+    }
+    return "";
+  };
+
+  const handleTextInputChange = (
+    val: string,
+    event: React.FormEvent<HTMLInputElement>
+  ) => {
+    const currentValue = field.value;
+    let newVal = '';
+    if (event.target.id.includes("column")) {
+      newVal = val+"&&"+getHashValue(currentValue)+"||"+getSaltValue(currentValue);
+    } else if(event.target.id === "hash") {
+      newVal = getColsValue(currentValue)+"&&"+val+"||"+getSaltValue(currentValue);
+    } else if(event.target.id === "salt") {
+      newVal = getColsValue(currentValue)+"&&"+getHashValue(currentValue)+"||"+val;
+    }
+    // console.log("MaskHashSalt.setFieldValue name: " + field.name + ", value: " + newVal);
+    props.setFieldValue(field.name, newVal, true);
+  };
+
+  const id = field.name;
+  const handleKeyPress = (keyEvent: KeyboardEvent) => {
+    // do not allow entry of '.' or '-'
+    if (keyEvent.key === "." || keyEvent.key === "-") {
+      keyEvent.preventDefault();
+    }
+  };
+
+  return (
+    <FormGroup
+      label={props.label}
+      isRequired={props.isRequired}
+      labelIcon={
+        <HelpInfoIcon label={props.label} description={props.description} />
+      }
+      helperTextInvalid={props.helperTextInvalid}
+      helperTextInvalidIcon={<ExclamationCircleIcon />}
+      fieldId={id}
+      validated={props.validated}
+    >
+      <InputGroup>
+        <Grid>
+          <GridItem span={5}>
+            <Flex className={'form-mask-hash-salt-component-column'}>
+              <FlexItem spacer={{ default: 'spacerXs' }}>Columns:</FlexItem>
+              <FlexItem className={'form-mask-hash-salt-component-column-input'}>
+                <TextInput 
+                  data-testid={id}
+                  id={id}
+                  type={"text"}
+                  validated={props.validated}
+                  onChange={handleTextInputChange}
+                  defaultValue={getColsValue(field.value)}
+                  onKeyPress={(event) => handleKeyPress(event as any)}
+                />
+              </FlexItem>
+            </Flex>
+          </GridItem>
+          <GridItem span={4}>
+            <Flex>
+              <FlexItem spacer={{ default: 'spacerXs' }}>Hash:</FlexItem>
+              <FlexItem spacer={{ default: 'spacerXs' }}>
+                <TextInput
+                  data-testid={id}
+                  id={"hash"}
+                  type={"text"}
+                  validated={props.validated}
+                  onChange={handleTextInputChange}
+                  defaultValue={getHashValue(field.value)}
+                  onKeyPress={(event) => handleKeyPress(event as any)}
+                />
+              </FlexItem>
+            </Flex>
+          </GridItem>
+          <GridItem span={3}>
+            <Flex>
+              <FlexItem spacer={{ default: 'spacerXs' }}>Salt:</FlexItem>
+              <FlexItem spacer={{ default: 'spacerXs' }}>
+                <TextInput
+                  data-testid={id}
+                  id={"salt"}
+                  type={"text"}
+                  validated={props.validated}
+                  onChange={handleTextInputChange}
+                  defaultValue={getSaltValue(field.value)}
+                  onKeyPress={(event) => handleKeyPress(event as any)}
+                />
+              </FlexItem>
+            </Flex>
+          </GridItem>
+        </Grid>
+      </InputGroup>
+    </FormGroup>
+  );
+};

--- a/ui/packages/ui/src/app/components/formHelpers/FormMaskOrTruncateComponent.tsx
+++ b/ui/packages/ui/src/app/components/formHelpers/FormMaskOrTruncateComponent.tsx
@@ -82,7 +82,7 @@ export const FormMaskOrTruncateComponent: React.FunctionComponent<IFormMaskOrTru
         <Grid>
           <GridItem span={9}>
             <Flex className={'form-mask-or-truncate-component-column'}>
-              <FlexItem>Column:</FlexItem>
+              <FlexItem spacer={{ default: 'spacerXs' }}>Columns:</FlexItem>
               <FlexItem className={'form-mask-or-truncate-component-column-input'}>
                 <TextInput 
                   data-testid={id}
@@ -98,7 +98,7 @@ export const FormMaskOrTruncateComponent: React.FunctionComponent<IFormMaskOrTru
           </GridItem>
           <GridItem span={3}>
             <Flex>
-              <FlexItem>n:</FlexItem>
+              <FlexItem spacer={{ default: 'spacerXs' }}>n:</FlexItem>
               <FlexItem>
                 <TextInput
                   min={"1"}


### PR DESCRIPTION
Adds UI component to handle the hash-salt masking property.
- using same strategy for the value as the column truncation and masking component, but 3 parts are combined instead of 2.  Different delimiters are used to separate the different segments
- added 'COLUMN_MASK_HASH_SALT' type in the model, so that the property can be distinguished from others
- made a couple of minor naming changes