### PR TITLE
Adds multiple hash-salt property capability

### DIFF
--- a/ui/packages/ui/src/app/components/formHelpers/FormComponent.tsx
+++ b/ui/packages/ui/src/app/components/formHelpers/FormComponent.tsx
@@ -102,6 +102,9 @@ export const FormComponent: React.FunctionComponent<IFormComponentProps> = (
         helperTextInvalid={props.helperTextInvalid}
         label={props.propertyDefinition.displayName}
         name={props.propertyDefinition.name}
+        i18nAddDefinitionText={t('addDefinition')}
+        i18nAddDefinitionTooltip={t('addDefinitionTooltip')}
+        i18nRemoveDefinitionTooltip={t('removeDefinitionTooltip')}
         propertyChange={props.propertyChange}
         setFieldValue={props.setFieldValue}
       />

--- a/ui/packages/ui/src/app/components/formHelpers/FormMaskHashSaltComponent.css
+++ b/ui/packages/ui/src/app/components/formHelpers/FormMaskHashSaltComponent.css
@@ -1,19 +1,8 @@
 .form-mask-hash-salt-component{
-    &-column{
-        margin-right: 20px;
-        &-input{
-            flex-grow:1;
-        }
-    }
-    &-label{
-        font-size: var(--pf-global--FontSize--sm);
-    }
-}
-.pf-l-flex{
-    &-nowrap{
-        flex-wrap: nowrap;
-        @media screen and (max-width: 1200px) {
-            flex-wrap: wrap;
-        }
-    }
+    padding-left: 5px;
+    padding-top: 5px;
+    border-width: 1px;
+    border-color: var(--pf-global--BorderColor--100);
+    border-style: solid;
+    border-radius: 5px;
 }

--- a/ui/packages/ui/src/app/components/formHelpers/FormMaskOrTruncateComponent.css
+++ b/ui/packages/ui/src/app/components/formHelpers/FormMaskOrTruncateComponent.css
@@ -4,4 +4,5 @@
     border-width: 1px;
     border-color: var(--pf-global--BorderColor--100);
     border-style: solid;
+    border-radius: 5px;
 }

--- a/ui/packages/ui/src/app/components/formHelpers/MaskHashSaltItem.css
+++ b/ui/packages/ui/src/app/components/formHelpers/MaskHashSaltItem.css
@@ -1,0 +1,27 @@
+.mask-hash-salt-item{
+    &-column{
+        margin-right: 20px;
+        &-input{
+            flex-grow:1;
+        }
+    }
+    &-label{
+        font-size: var(--pf-global--FontSize--sm);
+    }
+    &-remove-button{
+        margin-left: 10px;
+        padding-top: 5px;
+        &-icon{
+            color: var(--pf-global--palette--red-100);
+            cursor: pointer;
+        }
+    }
+}
+.pf-l-flex{
+    &-nowrap{
+        flex-wrap: nowrap;
+        @media screen and (max-width: 1200px) {
+            flex-wrap: wrap;
+        }
+    }
+}

--- a/ui/packages/ui/src/app/components/formHelpers/MaskHashSaltItem.tsx
+++ b/ui/packages/ui/src/app/components/formHelpers/MaskHashSaltItem.tsx
@@ -1,0 +1,160 @@
+import {
+  Flex,
+  FlexItem,
+  Grid,
+  GridItem,
+  Select,
+  SelectOption,
+  SelectVariant, TextInput, Tooltip
+} from "@patternfly/react-core";
+import { MinusCircleIcon } from "@patternfly/react-icons";
+import * as React from "react";
+import "./MaskHashSaltItem.css";
+
+export interface IMaskHashSaltItemProps {
+  rowId: number;
+  columnsValue: string;
+  hashValue: string;
+  saltValue: string;
+  canDelete: boolean;
+  i18nRemoveDefinitionTooltip: string;
+  maskHashSaltItemChanged: (rowId: number, maskHashSaltValue: string) => void;
+  deleteMaskHashSaltItem: (rowId: number) => void;
+}
+
+export const MaskHashSaltItem: React.FunctionComponent<IMaskHashSaltItemProps> = (
+  props
+) => {
+  const [isOpen, setOpen] = React.useState<boolean>(false)
+
+  const onToggle = (open: boolean) => {
+    setOpen(open)
+  };
+
+  const selectOptions = [
+    {"value": "Choose...", isPlaceholder: true},
+    {"value": "MD2"},
+    {"value": "MD5"}, 
+    {"value": "SHA-1"}, 
+    {"value": "SHA-256"}, 
+    {"value": "SHA-384"}, 
+    {"value": "SHA-512"}
+  ]
+
+  const handleColumnsChange = (val: any) => {
+    handleItemValueChange(val, props.hashValue, props.saltValue);
+  }
+
+  const handleHashChange = (event: any, selection: any, isPlaceholder: any) => {
+    const hashVal = isPlaceholder ? '' : selection;
+    setOpen(false);
+    handleItemValueChange(props.columnsValue, hashVal, props.saltValue);
+  };
+
+  const handleSaltChange = (val: any) => {
+    handleItemValueChange(props.columnsValue, props.hashValue, val);
+  }
+
+  const handleItemValueChange = (columns: any, hash: any, salt: any) => {
+    const newValue = columns + "&&" + hash + "||" + salt;
+    props.maskHashSaltItemChanged(props.rowId, newValue);
+  }
+
+  const handleRemoveItemClick = () => {
+    props.deleteMaskHashSaltItem(props.rowId);
+  }
+
+  const handleKeyPress = (keyEvent: KeyboardEvent) => {
+    // do not allow entry of '.' or '-'
+    if (keyEvent.key === "." || keyEvent.key === "-") {
+      keyEvent.preventDefault();
+    }
+  };
+
+  return (
+    <Grid>
+      <GridItem span={5}>
+        <Flex className={"mask-hash-salt-item-column"}>
+          <FlexItem
+            spacer={{ default: "spacerXs" }}
+            className="mask-hash-salt-item-label"
+          >
+            Columns:
+          </FlexItem>
+          <FlexItem className={"mask-hash-salt-item-column-input"}>
+            <TextInput
+              data-testid={`${props.rowId}columns`}
+              id={`${props.rowId}columns`}
+              type={"text"}
+              onChange={handleColumnsChange}
+              value={props.columnsValue}
+              onKeyPress={(event) => handleKeyPress(event as any)}
+            />
+          </FlexItem>
+        </Flex>
+      </GridItem>
+      <GridItem span={3}>
+        <Flex>
+          <FlexItem
+            spacer={{ default: "spacerXs" }}
+            className="mask-hash-salt-item-label"
+          >
+            Hash:
+          </FlexItem>
+          <FlexItem spacer={{ default: "spacerXs" }}>
+            <Select
+              variant={SelectVariant.single}
+              aria-label="Select Input"
+              onToggle={onToggle}
+              onSelect={handleHashChange}
+              selections={props.hashValue}
+              isOpen={isOpen}
+            >
+              {selectOptions.map((option, index) => (
+                <SelectOption
+                  key={index}
+                  value={option.value}
+                  isPlaceholder={option.isPlaceholder}
+                />
+              ))}
+            </Select>
+          </FlexItem>
+        </Flex>
+      </GridItem>
+      <GridItem span={3}>
+        <Flex className="pf-l-flex-nowrap">
+          <FlexItem
+            spacer={{ default: "spacerXs" }}
+            className="mask-hash-salt-item-label"
+          >
+            Salt:
+          </FlexItem>
+          <FlexItem spacer={{ default: "spacerXs" }}>
+            <TextInput
+              data-testid={`${props.rowId}salt`}
+              id={`${props.rowId}salt`}
+              type={"text"}
+              onChange={handleSaltChange}
+              value={props.saltValue}
+              onKeyPress={(event) => handleKeyPress(event as any)}
+            />
+          </FlexItem>
+        </Flex>
+      </GridItem>
+      {props.canDelete ? (
+        <GridItem span={1}>
+          <Flex className={"mask-hash-salt-item-remove-button"}>
+            <FlexItem>
+              <Tooltip position="right" content={props.i18nRemoveDefinitionTooltip}>
+                <MinusCircleIcon
+                  className={"mask-hash-salt-item-remove-button-icon"}
+                  onClick={handleRemoveItemClick}
+                />
+              </Tooltip>
+            </FlexItem>
+          </Flex>
+        </GridItem>
+      ) : null}
+    </Grid>
+  );
+};

--- a/ui/packages/ui/src/app/shared/Utils.ts
+++ b/ui/packages/ui/src/app/shared/Utils.ts
@@ -287,13 +287,19 @@ export function minimizePropertyValues (propertyValues: Map<string, string>, pro
           }
         }
       }else if(propDefn.name.startsWith("column_mask_hash") && value !== "") {
-        // The value is of form : Cols&&Hash||Salt - where && and || are used as separators
-        const [cols, trailing] = value.split("&&");
-        if (trailing) {
-          const [hash, salt] = trailing.split("||");
-          if(cols !== "" && hash !== "" && salt && salt !== ""){
-            const updatedKey = "column.mask.hash.([^.]+).with.salt.(.+)".replace("([^.]+)",hash).replace("(.+)",salt);
-            minimizedValues.set(updatedKey, cols);
+        // The value value can have multiple entries (entries are separated by '#$')
+        // Example Cols&&Hash||Salt #$ Cols&&Hash||Salt
+        const entries = value.split("#$");
+        for(const entry of entries) {
+          if (entry && entry !== "") {
+            const [cols, trailing] = entry.split("&&");
+            if (trailing) {
+              const [hash, salt] = trailing.split("||");
+              if(cols !== "" && hash !== "" && salt && salt !== ""){
+                const updatedKey = "column.mask.hash.([^.]+).with.salt.(.+)".replace("([^.]+)",hash).replace("(.+)",salt);
+                minimizedValues.set(updatedKey, cols);
+              }
+            }
           }
         }
       // Include non-mandatory if no default, and not empty


### PR DESCRIPTION
This adds the multi-row capability to the 'MaskHashSalt' component.  Took a similar approach as with the other multi-row property, breaking the item out into a separate component.