### PR TITLE
Fixed the alert spinner in table selection step

### DIFF
--- a/ui/packages/ui/src/app/pages/createConnector/connectorSteps/TableSelectionStep.tsx
+++ b/ui/packages/ui/src/app/pages/createConnector/connectorSteps/TableSelectionStep.tsx
@@ -435,7 +435,7 @@ export const TableSelectionStep: React.FunctionComponent<ITableSelectionStepProp
         </ActionGroup>
       </Form>
       <Divider />
-      {loading ? (
+      {!apiError && (loading ? (
         <Spinner />
       ) : (invalidMsg?.size !== 0) ? (
         <Alert
@@ -464,7 +464,7 @@ export const TableSelectionStep: React.FunctionComponent<ITableSelectionStepProp
           isInline={true}
           title={`${tableNo} ${props.i18nFilterExpressionResultText}`}
         />
-      )}
+      ))}
 
       <FilterTreeComponent
         treeData={treeData}


### PR DESCRIPTION
Fix for removing the spinner in case of API error in the table selection step.