### PR TITLE
Fix issue with wizard next button

### DIFF
--- a/ui/packages/ui/src/app/pages/createConnector/CreateConnectorComponent.tsx
+++ b/ui/packages/ui/src/app/pages/createConnector/CreateConnectorComponent.tsx
@@ -189,12 +189,12 @@ export const CreateConnectorComponent: React.FunctionComponent<ICreateConnectorC
   const dataOptionRef = React.useRef();
   const runtimeOptionRef = React.useRef();
 
-const onBackButtonEvent = (e:any) => {
+  const onBackButtonEvent = (e:any) => {
     e.preventDefault();
     if (!backEnable) {
         setShowBackConfirmationDialog(true);
     }
-}
+  }
 
   React.useEffect(() => {
     window.history.pushState(null, '', basename+history.location.pathname);
@@ -404,7 +404,12 @@ const onBackButtonEvent = (e:any) => {
       setSelectedConnectorPropertyDefns(getFormattedProperties(connType!.properties, connType));
       initPropertyValues();
     }
+    setConnectionPropsValid(false);
+    setConnectionPropsValidMsg([]);
+    setConnectionStepsValid(0);
+    setStepIdReached(1);
   };
+
   const filterConfigurationPageContentObj: any = getFilterConfigurationPageContent(selectedConnectorType || "");
 
   const initPropertyValues = (): void => {
@@ -451,7 +456,7 @@ const onBackButtonEvent = (e:any) => {
 
   const validateConnectionName = (connName: string | undefined): string => {
     const currentNames = props.connectorNames;
-    if (currentNames.indexOf(connName) > -1) {
+    if (connName && currentNames.indexOf(connName) > -1) {
       return t("duplicateConnectorErrorMsg");
     }
     return "";
@@ -1086,19 +1091,9 @@ const onBackButtonEvent = (e:any) => {
         i18nConfirmButtonText={t("leave")}
         i18nConfirmationMessage={t("cancelWarningMsg")}
         i18nTitle={t("exitWizard")}
-        showDialog={showCancelConfirmationDialog}
-        onCancel={doCancelConfirmed}
-        onConfirm={doGotoConnectorsListPage}
-      />
-      <ConfirmationDialog
-        buttonStyle={ConfirmationButtonStyle.NORMAL}
-        i18nCancelButtonText={t("stay")}
-        i18nConfirmButtonText={t("leave")}
-        i18nConfirmationMessage={t("cancelWarningMsg")}
-        i18nTitle={t("exitWizard")}
-        showDialog={showBackConfirmationDialog}
-        onCancel={doStay}
-        onConfirm={doGotoBack}
+        showDialog={ (showCancelConfirmationDialog || showBackConfirmationDialog) }
+        onCancel={ showCancelConfirmationDialog ? doCancelConfirmed: doStay }
+        onConfirm={ showCancelConfirmationDialog ? doGotoConnectorsListPage : doGotoBack }
       />
     </>
   );

--- a/ui/packages/ui/src/app/shared/Utils.ts
+++ b/ui/packages/ui/src/app/shared/Utils.ts
@@ -346,7 +346,8 @@ export function getFormattedProperties (propertyDefns: ConnectorProperty[], conn
 
   if (connectorType.id === ConnectorTypeId.POSTGRES) {
     for (const propDefn of formattedPropertyDefns) {
-      switch (propDefn.name) {
+      const propName = propDefn.name.replace(/_/g, ".");  // Ensure dotted version of name
+      switch (propName) {
         case PropertyName.BINARY_HANDLING_MODE:
         case PropertyName.DECIMAL_HANDLING_MODE:
         case PropertyName.HSTORE_HANDLING_MODE:
@@ -412,7 +413,8 @@ export function getFormattedProperties (propertyDefns: ConnectorProperty[], conn
     }
   } else if (connectorType.id === ConnectorTypeId.MONGO) {
     for (const propDefn of formattedPropertyDefns) {
-      switch (propDefn.name) {
+      const propName = propDefn.name.replace(/_/g, ".");  // Ensure dotted version of name
+      switch (propName) {
         case PropertyName.MONGODB_MEMBERS_AUTO_DISCOVER:
           propDefn.gridWidth = 12;
           propDefn.type = "BOOLEAN-SWITCH";
@@ -457,7 +459,6 @@ export function getFormattedProperties (propertyDefns: ConnectorProperty[], conn
       }
     }
   }
- 
   return formattedPropertyDefns;
 }
 


### PR DESCRIPTION
Fix for issue #271 - next button was remaining enabled after connector type change
- Reset some states after connectorType change, to re-init
- combining 2 ConfirmationDialog usages into 1
- Utils fix to ensure propNames are properly matched (was losing formatting after form validations due to formik name adjustments)