### PR TITLE
Updated the browser back button confirm handling by using prompt

### DIFF
--- a/ui/packages/ui/src/app/app.tsx
+++ b/ui/packages/ui/src/app/app.tsx
@@ -1,22 +1,67 @@
 import React from "react";
-import { I18nextProvider } from 'react-i18next';
+import { I18nextProvider, useTranslation } from "react-i18next";
 import { BrowserRouter as Router } from "react-router-dom";
 import "./app.css";
-import i18n from './i18n';
+import i18n from "./i18n";
 import AppLayout from "./Layout/AppLayout";
-import { RenderRoutes, ROUTES, WithErrorBoundary } from "./shared";
+import {
+  ConfirmationButtonStyle,
+  ConfirmationDialog,
+  RenderRoutes,
+  ROUTES,
+  WithErrorBoundary,
+} from "./shared";
 
 const App: React.FC = () => {
-	return (
-    <Router basename="/#app">
+  const [confirm, setConfirm] = React.useState(false);
+  const [confirmCallback, setConfirmCallback] = React.useState(null);
+  const getConfirmation = (message: any, callback: any) => {
+    setConfirmCallback(() => callback);
+    setConfirm(true);
+  };
+  return (
+    <Router basename="/#app" getUserConfirmation={getConfirmation}>
       <I18nextProvider i18n={i18n}>
         <AppLayout>
           <WithErrorBoundary>
             <RenderRoutes routes={ROUTES} />
+            {confirm && (
+              <UserConfirm
+                confirmCallback={confirmCallback}
+                setConfirm={setConfirm}
+              />
+            )}
           </WithErrorBoundary>
         </AppLayout>
       </I18nextProvider>
     </Router>
   );
-}
+};
 export default App;
+
+const UserConfirm = (props: any) => {
+  const { t } = useTranslation(["app"]);
+  
+  function allowTransition() {
+    props.setConfirm(false);
+    props.confirmCallback(true);
+  }
+
+  function blockTransition() {
+    props.setConfirm(false);
+    props.confirmCallback(false);
+  }
+
+  return (
+    <ConfirmationDialog
+      buttonStyle={ConfirmationButtonStyle.NORMAL}
+      i18nCancelButtonText={t("stay")}
+      i18nConfirmButtonText={t("leave")}
+      i18nConfirmationMessage={t("cancelWarningMsg")}
+      i18nTitle={t("exitWizard")}
+      showDialog={true}
+      onCancel={blockTransition}
+      onConfirm={allowTransition}
+    />
+  );
+};

--- a/ui/packages/ui/src/app/app.tsx
+++ b/ui/packages/ui/src/app/app.tsx
@@ -16,8 +16,12 @@ const App: React.FC = () => {
   const [confirm, setConfirm] = React.useState(false);
   const [confirmCallback, setConfirmCallback] = React.useState(null);
   const getConfirmation = (message: any, callback: any) => {
-    setConfirmCallback(() => callback);
-    setConfirm(true);
+    if(message === 'Code navigation'){
+      callback(true);
+    }else{
+      setConfirmCallback(() => callback);
+      setConfirm(true);
+    }
   };
   return (
     <Router basename="/#app" getUserConfirmation={getConfirmation}>

--- a/ui/packages/ui/src/app/pages/createConnector/CreateConnectorComponent.tsx
+++ b/ui/packages/ui/src/app/pages/createConnector/CreateConnectorComponent.tsx
@@ -23,7 +23,7 @@ import {
 import _ from "lodash";
 import React, { Dispatch, ReactNode, SetStateAction } from "react";
 import { useTranslation } from "react-i18next";
-import { useHistory } from "react-router-dom";
+import { Prompt, useHistory } from "react-router-dom";
 import { ToastAlertComponent } from "src/app/components";
 import {
   ConfirmationButtonStyle,
@@ -147,7 +147,6 @@ export const CreateConnectorComponent: React.FunctionComponent<ICreateConnectorC
     runtimeOptionsPropValues,
     setRuntimeOptionsPropValues,
   ] = React.useState<Map<string, string>>(new Map<string, string>());
-  const [backEnable, setBackEnable] = React.useState(false);
 
   const [validateInProgress, setValidateInProgress] = React.useState(false);
   const [loading, setLoading] = React.useState(true);
@@ -157,11 +156,6 @@ export const CreateConnectorComponent: React.FunctionComponent<ICreateConnectorC
   const [
     showCancelConfirmationDialog,
     setShowCancelConfirmationDialog,
-  ] = React.useState(false);
-
-  const [
-    showBackConfirmationDialog,
-    setShowBackConfirmationDialog,
   ] = React.useState(false);
 
   const [connectionStepsValid, setConnectionStepsValid] = React.useState<
@@ -188,23 +182,6 @@ export const CreateConnectorComponent: React.FunctionComponent<ICreateConnectorC
   const connectionPropsRef = React.useRef();
   const dataOptionRef = React.useRef();
   const runtimeOptionRef = React.useRef();
-
-  const onBackButtonEvent = (e:any) => {
-    e.preventDefault();
-    if (!backEnable) {
-        setShowBackConfirmationDialog(true);
-    }
-  }
-
-  React.useEffect(() => {
-    window.history.pushState(null, '', basename+history.location.pathname);
-    window.addEventListener('popstate', onBackButtonEvent);
-    return () => {
-      window.removeEventListener('popstate', onBackButtonEvent);  
-    };
-  }, []);
-
-
 
   const addAlert = (msg?: string) => {
     const alertsCopy = [...alerts];
@@ -319,21 +296,9 @@ export const CreateConnectorComponent: React.FunctionComponent<ICreateConnectorC
     setShowCancelConfirmationDialog(false);
   };
 
-  const doStay = () => {
-    setShowBackConfirmationDialog(false);
-    window.history.pushState(null, '', basename+history.location.pathname);
-    setBackEnable(false)
-  };
-
   const doGotoConnectorsListPage = () => {
     setShowCancelConfirmationDialog(false);
     props.onCancelCallback();
-  };
-
-  const doGotoBack = () => {
-    setShowBackConfirmationDialog(false);
-    setBackEnable(true);
-    history.goBack();
   };
 
   const onCancel = () => {
@@ -1078,22 +1043,36 @@ export const CreateConnectorComponent: React.FunctionComponent<ICreateConnectorC
 
   return (
     <>
+      <Prompt
+        message={(location: any, action: any) => {
+          if (action === "POP") {
+            // Going back...
+          }
+          return location.pathname.startsWith("/app")
+            ? true
+            : `Are you sure you want to go to ${location.pathname}?`;
+        }}
+      />
       <Wizard
         onClose={onCancel}
         footer={CustomFooter}
         steps={wizardSteps}
         className="create-connector-page_wizard"
       />
-      <ToastAlertComponent alerts={alerts} removeAlert={removeAlert} i18nDetails={t('details')}/>
+      <ToastAlertComponent
+        alerts={alerts}
+        removeAlert={removeAlert}
+        i18nDetails={t("details")}
+      />
       <ConfirmationDialog
         buttonStyle={ConfirmationButtonStyle.NORMAL}
         i18nCancelButtonText={t("stay")}
         i18nConfirmButtonText={t("leave")}
         i18nConfirmationMessage={t("cancelWarningMsg")}
         i18nTitle={t("exitWizard")}
-        showDialog={ (showCancelConfirmationDialog || showBackConfirmationDialog) }
-        onCancel={ showCancelConfirmationDialog ? doCancelConfirmed: doStay }
-        onConfirm={ showCancelConfirmationDialog ? doGotoConnectorsListPage : doGotoBack }
+        showDialog={showCancelConfirmationDialog}
+        onCancel={doCancelConfirmed}
+        onConfirm={doGotoConnectorsListPage}
       />
     </>
   );

--- a/ui/packages/ui/src/app/pages/createConnector/CreateConnectorComponent.tsx
+++ b/ui/packages/ui/src/app/pages/createConnector/CreateConnectorComponent.tsx
@@ -23,7 +23,7 @@ import {
 import _ from "lodash";
 import React, { Dispatch, ReactNode, SetStateAction } from "react";
 import { useTranslation } from "react-i18next";
-import { Prompt, useHistory } from "react-router-dom";
+import { Prompt } from "react-router-dom";
 import { ToastAlertComponent } from "src/app/components";
 import {
   ConfirmationButtonStyle,
@@ -75,7 +75,6 @@ function getSortedConnectorTypes(connectorTypes: ConnectorType[]) {
 type IOnSuccessCallbackFn = () => void;
 
 type IOnCancelCallbackFn = () => void;
-const basename = "/#app"
 
 export interface ICreateConnectorComponentProps {
   onSuccessCallback: IOnSuccessCallbackFn;
@@ -113,8 +112,6 @@ export const CreateConnectorComponent: React.FunctionComponent<ICreateConnectorC
   const DATA_OPTIONS_STEP_ID = 4;
   const RUNTIME_OPTIONS_STEP_ID = 5;
   const REVIEW_STEP_ID = 6;
-
-  const history = useHistory();
 
   const [stepIdReached, setStepIdReached] = React.useState(1);
   const [selectedConnectorType, setSelectedConnectorType] = React.useState<
@@ -298,6 +295,7 @@ export const CreateConnectorComponent: React.FunctionComponent<ICreateConnectorC
 
   const doGotoConnectorsListPage = () => {
     setShowCancelConfirmationDialog(false);
+    // On cancel, redirect to connectors page
     props.onCancelCallback();
   };
 
@@ -1044,13 +1042,10 @@ export const CreateConnectorComponent: React.FunctionComponent<ICreateConnectorC
   return (
     <>
       <Prompt
-        message={(location: any, action: any) => {
-          if (action === "POP") {
-            // Going back...
-          }
-          return location.pathname.startsWith("/app")
-            ? true
-            : `Are you sure you want to go to ${location.pathname}?`;
+        message={(location, action) => {
+          return action !== "POP"
+            ? `Code navigation`
+            : `Browser back navigation to ${location.pathname}?`;
         }}
       />
       <Wizard


### PR DESCRIPTION
Fixed issue https://github.com/debezium/debezium-ui-poc/issues/258
Updated the browser back button confirm implementation code, now using `<Prompt>` available in react-router to check the back event and rendering custom UI. 