### PR TITLE
Adding connector actions Pause / Resume / Restart

### DIFF
--- a/ui/packages/services/src/connector/connector.service.ts
+++ b/ui/packages/services/src/connector/connector.service.ts
@@ -15,10 +15,8 @@
  * limitations under the License.
  */
 
-import {
-    Connector, ConnectionValidationResult, FilterValidationResult, PropertiesValidationResult
-} from "@debezium/ui-models";
-import {BaseService} from "../baseService";
+import { ConnectionValidationResult, Connector, FilterValidationResult, PropertiesValidationResult } from "@debezium/ui-models";
+import { BaseService } from "../baseService";
 
 /**
  * The connector service.  Used to fetch connectors and other connector operations.
@@ -130,5 +128,35 @@ export class ConnectorService extends BaseService {
         const endpoint: string = this.endpoint("/connectors/:clusterId/:connectorName", { clusterId, connectorName });
         return this.httpDelete<any>(endpoint);
     }
+
+    /**
+     * Pause the Connector for the supplied clusterId
+     */
+    public pauseConnector(clusterId: number, connectorName: string, body: any): Promise<void> {
+        this.logger.info("[ConnectorService] Pause the connector");
+
+        const endpoint: string = this.endpoint("/connectors/:clusterId/:connectorName", { clusterId, connectorName });
+        return this.httpPost(endpoint, body);
+    }
+    
+    /**
+     * Resume the Connector for the supplied clusterId
+     */
+    public resumeConnector(clusterId: number, connectorName: string, body: any): Promise<void> {
+        this.logger.info("[ConnectorService] Resume the connector");
+
+        const endpoint: string = this.endpoint("/connectors/:clusterId/:connectorName", { clusterId, connectorName });
+        return this.httpPost(endpoint, body);
+    }
+    
+    /**
+     * Restart the Connector for the supplied clusterId
+     */
+    public restartConnector(clusterId: number, connectorName: string, body: any): Promise<void> {
+        this.logger.info("[ConnectorService] Restart the connector");
+
+        const endpoint: string = this.endpoint("/connectors/:clusterId/:connectorName", { clusterId, connectorName });
+        return this.httpPost(endpoint, body);
+    }    
 
 }

--- a/ui/packages/ui/src/app/i18n/locales/translations.en.json
+++ b/ui/packages/ui/src/app/i18n/locales/translations.en.json
@@ -10,6 +10,9 @@
     "heartbeatProperties": "Heartbeat properties",
     "mappingPropertiesText": "Mapping properties",
     "snapshotPropertiesText": "Snapshot properties",
+    "pause": "Pause",
+    "resume":"Resume",
+    "restart":"Restart",
     "delete": "Delete",
     "name": "Name",
     "reviewMessage": "Review the properties to be used for creation of connector '{{connectorName}}'. Click 'Finish' to create the connector.",
@@ -76,6 +79,18 @@
     "addDefinition": "+ Add definition",
     "addDefinitionTooltip": "Add another definition row",
     "removeDefinitionTooltip": "Remove this definition row",
-    "propertyValidationError": "Property validation error"
+    "propertyValidationError": "Property validation error",
+    "pauseConnector": "Pause connector",
+    "resumeConnector": "Resume connector",
+    "restartConnector": "Restart connector",
+    "connectorPauseWarningMsg": "Are you sure want to pause?",
+    "connectorResumeWarningMsg": "Are you sure want to resume?",
+    "connectorRestartWarningMsg": "Are you sure want to restart?",
+    "connectorPausedSuccess": "Connector paused successfully!",
+    "connectorPauseFailed": "Connector pause failed!",
+    "connectorResumedSuccess": "Connector resumed successfully!",
+    "connectorResumeFailed": "Connector resume failed!",
+    "connectorRestartSuccess": "Connector restarted successfully!",
+    "connectorRestartFailed": "Connector restart failed!"
   }
 }

--- a/ui/packages/ui/src/app/i18n/locales/translations.it.json
+++ b/ui/packages/ui/src/app/i18n/locales/translations.it.json
@@ -10,6 +10,9 @@
     "heartbeatProperties": "Proprietà del battito cardiaco",
     "mappingPropertiesText": "Proprietà di mappatura",
     "snapshotPropertiesText": "Proprietà snapshot",
+    "pause": "Pausa",
+    "resume":"Riprendere",
+    "restart":"Ricomincia",
     "delete": "Elimina",
     "name": "Nome",
     "reviewMessage": "Rivedere le proprietà da utilizzare per la creazione del connettore '{{connectorName}}'. Fare clic su 'Fine' per creare il connettore.",
@@ -76,6 +79,18 @@
     "addDefinition": "+ Aggiungi definizione",
     "addDefinitionTooltip": "Aggiungere un'altra riga definizione",
     "removeDefinitionTooltip": "Rimuovi questa riga di definizione",
-    "propertyValidationError": "Errore di convalida della proprietà"
+    "propertyValidationError": "Errore di convalida della proprietà",
+    "pauseConnector": "Connettore di pausa",
+    "resumeConnector": "Riprendi connettore",
+    "restartConnector": "Riavvia connettore",
+    "connectorPauseWarningMsg": "Sei sicuro di voler mettere in pausa?",
+    "connectorResumeWarningMsg": "Sei sicuro di voler riprendere?",
+    "connectorRestartWarningMsg": "Sei sicuro di voler riavviare?",
+    "connectorPausedSuccess": "Connettore messo in pausa con successo!",
+    "connectorPauseFailed": "Pausa connettore non riuscita!",
+    "connectorResumedSuccess": "Il connettore è stato ripristinato correttamente!",
+    "connectorResumeFailed": "Ripresa connettore non riuscita!",
+    "connectorRestartSuccess": "Connettore riavviato con successo!",
+    "connectorRestartFailed": "Riavvio del connettore non riuscito!"
   }
 }


### PR DESCRIPTION
- Added connector service mock for Pause / Resume / Restart service call.
- Using `httpPost` method as of now, will replace according to backend implementation