### PR TITLE
Adding display of connector type within wizard pages

### DIFF
--- a/ui/packages/ui/src/app/pages/createConnector/CreateConnectorComponent.tsx
+++ b/ui/packages/ui/src/app/pages/createConnector/CreateConnectorComponent.tsx
@@ -50,6 +50,7 @@ import {
   ReviewStepComponent,
   RuntimeOptionsComponent,
 } from "./connectorSteps";
+import { ConnectorNameTypeHeader } from './connectorSteps/ConnectorNameTypeHeader';
 import "./CreateConnectorComponent.css";
 
 /**
@@ -92,7 +93,7 @@ export const CreateConnectorComponent: React.FunctionComponent<ICreateConnectorC
   const createConnectorUnknownErrorMsg = t("unknownError");
   const CONNECTOR_TYPE_STEP = (
     <div>
-      {t("connectorType")} <span className="pf-m-required"> *</span>
+     {t("connectorType")} <span className="pf-m-required"> *</span>
     </div>
   );
   const PROPERTIES_STEP = (
@@ -105,7 +106,7 @@ export const CreateConnectorComponent: React.FunctionComponent<ICreateConnectorC
   const RUNTIME_OPTIONS_STEP = t("runtimeOptions");
   const REVIEW_STEP = t("review");
 
-  // const CONNECTOR_TYPE_STEP_ID = 1;
+  const CONNECTOR_TYPE_STEP_ID = 1;
   const PROPERTIES_STEP_ID = 2;
   const FILTER_CONFIGURATION_STEP_ID = 3;
   const DATA_OPTIONS_STEP_ID = 4;
@@ -196,11 +197,11 @@ export const CreateConnectorComponent: React.FunctionComponent<ICreateConnectorC
     setAlerts([...alerts.filter((el) => el.key !== key)]);
   };
 
-  const disableNextButton = (activeStepName: string): boolean => {
+  const disableNextButton = (activeStepId: any): boolean => {
     return (
-      (activeStepName === PROPERTIES_STEP && !connectionPropsValid) ||
-      (activeStepName === DATA_OPTIONS_STEP && !dataOptionsValid) ||
-      (activeStepName === RUNTIME_OPTIONS_STEP && !runtimeOptionsValid)
+      (activeStepId === PROPERTIES_STEP_ID && !connectionPropsValid) ||
+      (activeStepId === DATA_OPTIONS_STEP_ID && !dataOptionsValid) ||
+      (activeStepId === RUNTIME_OPTIONS_STEP_ID && !runtimeOptionsValid)
     );
   };
 
@@ -302,7 +303,7 @@ export const CreateConnectorComponent: React.FunctionComponent<ICreateConnectorC
     setShowCancelConfirmationDialog(true);
   };
 
-  const goToNext = (id: number, onNext: () => void) => {
+  const goToNext = (id: any, onNext: () => void) => {
     setConnectorCreateFailed(false);
     // tslint:disable-next-line: no-unused-expression
     id === 5 && setFinishStepId(RUNTIME_OPTIONS_STEP_ID);
@@ -623,6 +624,7 @@ export const CreateConnectorComponent: React.FunctionComponent<ICreateConnectorC
     component: (
       <>
         <PropertiesStep
+          connectorType={selectedConnectorType}
           basicPropertyDefinitions={getBasicPropertyDefinitions(
             selectedConnectorPropertyDefns
           )}
@@ -714,16 +716,19 @@ export const CreateConnectorComponent: React.FunctionComponent<ICreateConnectorC
         id: 3,
         name: FILTER_CONFIGURATION_STEP,
         component: (
-          <FilterConfigComponent
-            propertyValues={
-              new Map([...basicPropValues, ...advancedPropValues])
-            }
-            filterValues={filterValues}
-            updateFilterValues={handleFilterUpdate}
-            connectorType={selectedConnectorType || ""}
-            setIsValidFilter={setIsValidFilter}
-            selectedConnectorType={selectedConnectorType || ''}
-          />
+          <>
+            <ConnectorNameTypeHeader connectorName={getConnectorName()} connectorType={selectedConnectorType} />
+            <FilterConfigComponent
+              propertyValues={
+                new Map([...basicPropValues, ...advancedPropValues])
+              }
+              filterValues={filterValues}
+              updateFilterValues={handleFilterUpdate}
+              connectorType={selectedConnectorType || ""}
+              setIsValidFilter={setIsValidFilter}
+              selectedConnectorType={selectedConnectorType || ""}
+            />
+          </>
         ),
         canJumpTo: stepIdReached >= 3,
       },
@@ -732,6 +737,7 @@ export const CreateConnectorComponent: React.FunctionComponent<ICreateConnectorC
         name: DATA_OPTIONS_STEP,
         component: (
           <>
+            <ConnectorNameTypeHeader connectorName={getConnectorName()} connectorType={selectedConnectorType} />
             <DataOptionsComponent
               propertyDefinitions={getDataOptionsPropertyDefinitions(
                 selectedConnectorPropertyDefns
@@ -750,23 +756,20 @@ export const CreateConnectorComponent: React.FunctionComponent<ICreateConnectorC
             />
             {validateInProgress ? (
               <Spinner size="lg" />
-            ) : (
-              dataStepsValid === 1 && !dataOptionsValid ? 
-              (
-                <div style={{ padding: "15px 0" }}>
-                  <Alert
-                    variant="danger"
-                    isInline={true}
-                    title={
-                      <ConnectionPropertiesError
-                        connectionPropsMsg={connectionPropsValidMsg}
-                        validationErrorMsg={t("resolvePropertyErrorsMsg")}
-                      />
-                    }
-                  />
-                </div>
-              ) : null
-            )}
+            ) : dataStepsValid === 1 && !dataOptionsValid ? (
+              <div style={{ padding: "15px 0" }}>
+                <Alert
+                  variant="danger"
+                  isInline={true}
+                  title={
+                    <ConnectionPropertiesError
+                      connectionPropsMsg={connectionPropsValidMsg}
+                      validationErrorMsg={t("resolvePropertyErrorsMsg")}
+                    />
+                  }
+                />
+              </div>
+            ) : null}
           </>
         ),
         canJumpTo: stepIdReached >= 4,
@@ -776,6 +779,7 @@ export const CreateConnectorComponent: React.FunctionComponent<ICreateConnectorC
         name: RUNTIME_OPTIONS_STEP,
         component: (
           <>
+            <ConnectorNameTypeHeader connectorName={getConnectorName()} connectorType={selectedConnectorType} />
             <RuntimeOptionsComponent
               propertyDefinitions={getRuntimeOptionsPropertyDefinitions(
                 selectedConnectorPropertyDefns
@@ -791,24 +795,22 @@ export const CreateConnectorComponent: React.FunctionComponent<ICreateConnectorC
             />
             {validateInProgress ? (
               <Spinner size="lg" />
-            ) : (
-              runtimeStepsValid === 1 &&
-              !connectorCreateFailed && !runtimeOptionsValid ? 
-              (
-                <div style={{ padding: "15px 0" }}>
-                  <Alert
-                    variant="danger"
-                    isInline={true}
-                    title={
-                      <ConnectionPropertiesError
-                        connectionPropsMsg={connectionPropsValidMsg}
-                        validationErrorMsg={t("resolvePropertyErrorsMsg")}
-                      />
-                    }
-                  />
-                </div>
-              ) : null
-            )}
+            ) : runtimeStepsValid === 1 &&
+              !connectorCreateFailed &&
+              !runtimeOptionsValid ? (
+              <div style={{ padding: "15px 0" }}>
+                <Alert
+                  variant="danger"
+                  isInline={true}
+                  title={
+                    <ConnectionPropertiesError
+                      connectionPropsMsg={connectionPropsValidMsg}
+                      validationErrorMsg={t("resolvePropertyErrorsMsg")}
+                    />
+                  }
+                />
+              </div>
+            ) : null}
           </>
         ),
         canJumpTo: stepIdReached >= 5,
@@ -820,13 +822,16 @@ export const CreateConnectorComponent: React.FunctionComponent<ICreateConnectorC
     id: 6,
     name: REVIEW_STEP,
     component: (
-      <ReviewStepComponent
-        i18nReviewMessage={t("reviewMessage", {
-          connectorName: getConnectorName(),
-        })}
-        i18nReviewTitle={t("reviewTitle")}
-        propertyValues={getFinalProperties(finishStepId)}
-      />
+      <>
+        <ConnectorNameTypeHeader connectorName={getConnectorName()} connectorType={selectedConnectorType} />
+        <ReviewStepComponent
+          i18nReviewMessage={t("reviewMessage", {
+            connectorName: getConnectorName(),
+          })}
+          i18nReviewTitle={t("reviewTitle")}
+          propertyValues={getFinalProperties(finishStepId)}
+        />
+      </>
     ),
     canJumpTo: stepIdReached >= 2,
     nextButtonText: t("finish"),
@@ -855,7 +860,7 @@ export const CreateConnectorComponent: React.FunctionComponent<ICreateConnectorC
               {activeStep.id &&
                 activeStep.id > 2 &&
                 activeStep.id !== 6 &&
-                !disableNextButton(activeStep.name) && (
+                !disableNextButton(activeStep.id) && (
                   <div className="skipToNextInfoBox">
                     <NotificationDrawer>
                       <NotificationDrawerBody>
@@ -922,20 +927,20 @@ export const CreateConnectorComponent: React.FunctionComponent<ICreateConnectorC
                 <></>
               )}
 
-              {activeStep.name === REVIEW_STEP ? (
+              {activeStep.id === REVIEW_STEP_ID ? (
                 // Final step buttons
                 <Button variant="primary" type="submit" onClick={onFinish}>
                   {t('finish')}
                 </Button>
-              ) : disableNextButton(activeStep.name) ? (
+              ) : disableNextButton(activeStep.id) ? (
                 <Button
                   isDisabled={true}
                   variant="primary"
                   type="submit"
                   className={
-                    (activeStep.name === FILTER_CONFIGURATION_STEP &&
+                    (activeStep.id === FILTER_CONFIGURATION_STEP_ID &&
                       !isValidFilter) ||
-                    (activeStep.name === CONNECTOR_TYPE_STEP &&
+                    (activeStep.id === CONNECTOR_TYPE_STEP_ID &&
                       selectedConnectorType === undefined)
                       ? "pf-m-disabled"
                       : ""
@@ -949,9 +954,9 @@ export const CreateConnectorComponent: React.FunctionComponent<ICreateConnectorC
                   variant="primary"
                   type="submit"
                   className={
-                    (activeStep.name === FILTER_CONFIGURATION_STEP &&
+                    (activeStep.id === FILTER_CONFIGURATION_STEP_ID &&
                       !isValidFilter) ||
-                    (activeStep.name === CONNECTOR_TYPE_STEP &&
+                    (activeStep.id === CONNECTOR_TYPE_STEP_ID &&
                       selectedConnectorType === undefined)
                       ? "pf-m-disabled"
                       : ""
@@ -969,7 +974,7 @@ export const CreateConnectorComponent: React.FunctionComponent<ICreateConnectorC
                     : onBack
                 }
                 className={
-                  activeStep.name === CONNECTOR_TYPE_STEP ? "pf-m-disabled" : ""
+                  activeStep.id === CONNECTOR_TYPE_STEP_ID ? "pf-m-disabled" : ""
                 }
               >
                 {t('back')}

--- a/ui/packages/ui/src/app/pages/createConnector/connectorSteps/ConnectorNameTypeHeader.css
+++ b/ui/packages/ui/src/app/pages/createConnector/connectorSteps/ConnectorNameTypeHeader.css
@@ -1,0 +1,13 @@
+.connector-name-type-header_name_label{
+  font-size: var(--pf-global--FontSize--l);
+  font-weight: var(--pf-global--FontWeight--bold);;
+  margin-right: 10px;
+  margin-bottom: 5px;
+}
+.connector-name-type-header_type_label{
+  font-size: var(--pf-global--FontSize--l);
+  font-weight: var(--pf-global--FontWeight--bold);;
+  margin-left: 20px;
+  margin-right: 5px;
+  margin-bottom: 5px;
+}

--- a/ui/packages/ui/src/app/pages/createConnector/connectorSteps/ConnectorNameTypeHeader.tsx
+++ b/ui/packages/ui/src/app/pages/createConnector/connectorSteps/ConnectorNameTypeHeader.tsx
@@ -1,0 +1,45 @@
+import {
+  Split,
+  SplitItem,
+  Text,
+  TextContent,
+  TextVariants,
+} from "@patternfly/react-core";
+import React from "react";
+import "./ConnectorNameTypeHeader.css";
+import { ConnectorTypeComponent } from './ConnectorTypeComponent';
+
+export interface IConnectorNameTypeHeaderProps {
+  connectorName?: string;
+  connectorType?: string;
+}
+
+export const ConnectorNameTypeHeader: React.FunctionComponent<IConnectorNameTypeHeaderProps> = (
+  props
+) => {
+
+  return (
+    <Split>
+      <SplitItem>
+        <TextContent>
+          <Text className={"connector-name-type-header_name_label"}>
+            Connector name:
+          </Text>
+        </TextContent>
+      </SplitItem>
+      <SplitItem>
+        <TextContent>
+          <Text component={TextVariants.p}>{props.connectorName}</Text>
+        </TextContent>
+      </SplitItem>
+      <SplitItem>
+        <TextContent>
+          <Text className={"connector-name-type-header_type_label"}>Type:</Text>
+        </TextContent>
+      </SplitItem>
+      <SplitItem>
+        <ConnectorTypeComponent connectorType={props.connectorType} />
+      </SplitItem>
+    </Split>
+  );
+};

--- a/ui/packages/ui/src/app/pages/createConnector/connectorSteps/ConnectorTypeComponent.css
+++ b/ui/packages/ui/src/app/pages/createConnector/connectorSteps/ConnectorTypeComponent.css
@@ -1,0 +1,3 @@
+.connector-type-icon{
+  margin-right: 5px;
+}

--- a/ui/packages/ui/src/app/pages/createConnector/connectorSteps/ConnectorTypeComponent.tsx
+++ b/ui/packages/ui/src/app/pages/createConnector/connectorSteps/ConnectorTypeComponent.tsx
@@ -1,0 +1,55 @@
+import {
+  Split,
+  SplitItem,
+  Text,
+  TextContent,
+  TextVariants,
+} from "@patternfly/react-core";
+import React from "react";
+import {
+  ConnectorTypeId,
+} from "src/app/shared";
+import { ConnectorIcon } from '../../connectors/ConnectorIcon';
+import "./ConnectorTypeComponent.css";
+
+export interface IConnectorTypeComponentProps {
+  connectorType?: string;
+}
+
+export const ConnectorTypeComponent: React.FunctionComponent<IConnectorTypeComponentProps> = (
+  props
+) => {
+
+  const displayName = () => {
+    if( props.connectorType === ConnectorTypeId.MONGO ) {
+      return "MongoDB";
+    } else if ( props.connectorType === ConnectorTypeId.POSTGRES ) {
+      return "PostgreSQL";
+    } else if ( props.connectorType === ConnectorTypeId.MYSQL ) {
+      return "MySQL";
+    } else if ( props.connectorType === ConnectorTypeId.SQLSERVER ) {
+      return "SQL Server";
+    }
+    return "Unknown";
+  }
+
+  return (
+    <Split>
+      {props.connectorType ? (
+        <SplitItem className="connector-type-icon">
+          <ConnectorIcon
+            connectorType={props.connectorType}
+            alt={props.connectorType}
+            width={30}
+            height={30}
+          />
+        </SplitItem>
+      ) : null}
+      <SplitItem>
+        <TextContent>
+          <Text component={TextVariants.p}>{displayName()}</Text>
+        </TextContent>
+      </SplitItem>
+    </Split>
+  );
+};

--- a/ui/packages/ui/src/app/pages/createConnector/connectorSteps/PropertiesStep.css
+++ b/ui/packages/ui/src/app/pages/createConnector/connectorSteps/PropertiesStep.css
@@ -1,6 +1,12 @@
 .connector-name-form{
   padding: 8px 0px;
 }
+.connector-type-label{
+  font-weight: var(--pf-c-form__label-text--FontWeight);
+  font-size: var(--pf-c-form__label--FontSize);
+  margin-top: 3px;
+  margin-right: 10px;
+}
 .properties-step {
   &-advanced-title {
     margin-top: 30px;

--- a/ui/packages/ui/src/app/pages/createConnector/connectorSteps/PropertiesStep.tsx
+++ b/ui/packages/ui/src/app/pages/createConnector/connectorSteps/PropertiesStep.tsx
@@ -3,6 +3,10 @@ import {
   ExpandableSection,
   Grid,
   GridItem,
+  Split,
+  SplitItem,
+  Text,
+  TextContent,
   Title
 } from "@patternfly/react-core";
 import { Form, Formik, useFormikContext } from "formik";
@@ -11,9 +15,11 @@ import * as React from "react";
 import { formatPropertyDefinitions, PropertyCategory, PropertyName } from "src/app/shared";
 import * as Yup from "yup";
 import { FormComponent } from "../../../components/formHelpers";
+import { ConnectorTypeComponent } from './ConnectorTypeComponent';
 import "./PropertiesStep.css";
 
 export interface IPropertiesStepProps {
+  connectorType: string | undefined;
   basicPropertyDefinitions: ConnectorProperty[];
   basicPropertyValues: Map<string, string>;
   advancedPropertyDefinitions: ConnectorProperty[];
@@ -198,8 +204,9 @@ export const PropertiesStep: React.FC<any> = React.forwardRef(
                           setFieldValue={setFieldValue}
                           helperTextInvalid={errors[propertyDefinition.name]}
                           invalidMsg={props.invalidMsg}
-                          validated={ errors[propertyDefinition.name] &&
-                            touched[propertyDefinition.name] 
+                          validated={
+                            errors[propertyDefinition.name] &&
+                            touched[propertyDefinition.name]
                               ? "error"
                               : "default"
                           }
@@ -208,6 +215,22 @@ export const PropertiesStep: React.FC<any> = React.forwardRef(
                     );
                   }
                 )}
+                <GridItem key={"connType"} lg={12} sm={12}>
+                  <Split>
+                    <SplitItem>
+                      <TextContent>
+                        <Text className={"connector-type-label"}>
+                          Connector type:
+                        </Text>
+                      </TextContent>
+                    </SplitItem>
+                    <SplitItem>
+                      <ConnectorTypeComponent
+                        connectorType={props.connectorType}
+                      />
+                    </SplitItem>
+                  </Split>
+                </GridItem>
               </Grid>
               <Grid>
                 <GridItem lg={9} sm={12}>
@@ -240,7 +263,8 @@ export const PropertiesStep: React.FC<any> = React.forwardRef(
                                   errors[propertyDefinition.name]
                                 }
                                 invalidMsg={props.invalidMsg}
-                                validated={ errors[propertyDefinition.name] &&
+                                validated={
+                                  errors[propertyDefinition.name] &&
                                   touched[propertyDefinition.name]
                                     ? "error"
                                     : "default"
@@ -285,7 +309,8 @@ export const PropertiesStep: React.FC<any> = React.forwardRef(
                                     errors[propertyDefinition.name]
                                   }
                                   invalidMsg={props.invalidMsg}
-                                  validated={errors[propertyDefinition.name] &&
+                                  validated={
+                                    errors[propertyDefinition.name] &&
                                     touched[propertyDefinition.name]
                                       ? "error"
                                       : "default"
@@ -329,7 +354,8 @@ export const PropertiesStep: React.FC<any> = React.forwardRef(
                                     errors[propertyDefinition.name]
                                   }
                                   invalidMsg={props.invalidMsg}
-                                  validated={ errors[propertyDefinition.name] &&
+                                  validated={
+                                    errors[propertyDefinition.name] &&
                                     touched[propertyDefinition.name]
                                       ? "error"
                                       : "default"


### PR DESCRIPTION
- Adds display of the connector type on the basic properties page, underneath the name input (see images below)
- Adds header showing the connector name/type on the subsequent wizard pages (see images below)
- changed activeStep.name comparisons in CreateConnectorComponent to activeStep.id comparison.  Think this would be more reliable, since some of the names are actually elements - not strings.

**_Connection Props step:_**
![PropertiesStep](https://user-images.githubusercontent.com/1820403/106197776-a957b780-6178-11eb-8b27-95b86b996706.png)


**_Subsequent wizard steps:_**
![OtherPropsStep](https://user-images.githubusercontent.com/1820403/106197807-b4aae300-6178-11eb-8087-d47d7ea532f0.png)
