### PR TITLE
added the invalid property name in generic error msg

### DIFF
--- a/ui/packages/ui/src/app/components/ConnectionPropertiesError.tsx
+++ b/ui/packages/ui/src/app/components/ConnectionPropertiesError.tsx
@@ -3,7 +3,8 @@ import React from 'react';
 
 export interface IConnectionPropertiesErrorProps{
     connectionPropsMsg: PropertyValidationResult[];
-    validationErrorMsg: string;
+    i18nFieldValidationErrorMsg: string;
+    i18nValidationErrorMsg: string;
 }
 
 export const ConnectionPropertiesError : React.FunctionComponent<IConnectionPropertiesErrorProps> = (props)=>{
@@ -12,12 +13,12 @@ export const ConnectionPropertiesError : React.FunctionComponent<IConnectionProp
           <ul>
             {props.connectionPropsMsg.map((item, index) => (
               <li key={index}>
-                {item.property === 'Generic' ? `${item.displayName}: ${item.message}` : props.validationErrorMsg}
+                {item.property === 'Generic' ? `${item.displayName}: ${item.message}` : props.i18nFieldValidationErrorMsg.replace("**", `${item.displayName}(${item.property})`)}
               </li>
             ))}
           </ul>
         );
       } else {
-        return <div>{props.validationErrorMsg}</div>;
+        return <div>{props.i18nValidationErrorMsg}</div>;
       }
 }

--- a/ui/packages/ui/src/app/i18n/locales/translations.en.json
+++ b/ui/packages/ui/src/app/i18n/locales/translations.en.json
@@ -82,6 +82,7 @@
     "reloadPage": "Reload page",
     "removeDefinitionTooltip": "Remove this definition row",
     "reportIssue": "Report the issue",
+    "resolveFieldErrorsMsg": "Resolve ** property errors, then click Validate",
     "resolvePropertyErrorsMsg": "Resolve property errors, then click Validate",
     "resolvePropertySucessMsg": "All required configuration is complete. If desired, you can proceed to",
     "resume":"Resume",

--- a/ui/packages/ui/src/app/i18n/locales/translations.it.json
+++ b/ui/packages/ui/src/app/i18n/locales/translations.it.json
@@ -82,6 +82,7 @@
     "reloadPage": "Ricarica la pagina",
     "removeDefinitionTooltip": "Rimuovi questa riga di definizione",
     "reportIssue": "Segnala il problema",
+    "resolveFieldErrorsMsg": "Risolvi ** gli errori di proprietà, quindi fai clic su Convalida",
     "resolvePropertyErrorsMsg": "Risolvi gli errori di proprietà, quindi fai clic su Convalida",
     "resolvePropertySucessMsg": "Tutta la configurazione richiesta è completa. Se lo desideri, puoi procedere a",
     "resume":"Riprendere",

--- a/ui/packages/ui/src/app/pages/createConnector/CreateConnectorComponent.tsx
+++ b/ui/packages/ui/src/app/pages/createConnector/CreateConnectorComponent.tsx
@@ -655,7 +655,8 @@ export const CreateConnectorComponent: React.FunctionComponent<ICreateConnectorC
                 title={
                   <ConnectionPropertiesError
                     connectionPropsMsg={connectionPropsValidMsg}
-                    validationErrorMsg={t("resolvePropertyErrorsMsg")}
+                    i18nFieldValidationErrorMsg={t("resolveFieldErrorsMsg")}
+                    i18nValidationErrorMsg={t("resolvePropertyErrorsMsg")}
                   />
                 }
               />
@@ -764,7 +765,8 @@ export const CreateConnectorComponent: React.FunctionComponent<ICreateConnectorC
                   title={
                     <ConnectionPropertiesError
                       connectionPropsMsg={connectionPropsValidMsg}
-                      validationErrorMsg={t("resolvePropertyErrorsMsg")}
+                      i18nFieldValidationErrorMsg={t("resolveFieldErrorsMsg")}
+                      i18nValidationErrorMsg={t("resolvePropertyErrorsMsg")}
                     />
                   }
                 />
@@ -805,7 +807,8 @@ export const CreateConnectorComponent: React.FunctionComponent<ICreateConnectorC
                   title={
                     <ConnectionPropertiesError
                       connectionPropsMsg={connectionPropsValidMsg}
-                      validationErrorMsg={t("resolvePropertyErrorsMsg")}
+                      i18nFieldValidationErrorMsg={t("resolveFieldErrorsMsg")}
+                      i18nValidationErrorMsg={t("resolvePropertyErrorsMsg")}
                     />
                   }
                 />


### PR DESCRIPTION
Added the `displayName(propery)` to generic error msg.
![image](https://user-images.githubusercontent.com/8264372/106269602-bd6fe780-6252-11eb-95ff-17527a3450df.png)
 