### PR TITLE
Update backend connector service calls

### DIFF
--- a/ui/packages/services/src/connector/connector.service.ts
+++ b/ui/packages/services/src/connector/connector.service.ts
@@ -135,8 +135,8 @@ export class ConnectorService extends BaseService {
     public pauseConnector(clusterId: number, connectorName: string, body: any): Promise<void> {
         this.logger.info("[ConnectorService] Pause the connector");
 
-        const endpoint: string = this.endpoint("/connectors/:clusterId/:connectorName", { clusterId, connectorName });
-        return this.httpPost(endpoint, body);
+        const endpoint: string = this.endpoint("/connector/:clusterId/:connectorName/pause", { clusterId, connectorName });
+        return this.httpPut(endpoint, body);
     }
     
     /**
@@ -145,8 +145,8 @@ export class ConnectorService extends BaseService {
     public resumeConnector(clusterId: number, connectorName: string, body: any): Promise<void> {
         this.logger.info("[ConnectorService] Resume the connector");
 
-        const endpoint: string = this.endpoint("/connectors/:clusterId/:connectorName", { clusterId, connectorName });
-        return this.httpPost(endpoint, body);
+        const endpoint: string = this.endpoint("/connector/:clusterId/:connectorName/resume", { clusterId, connectorName });
+        return this.httpPut(endpoint, body);
     }
     
     /**
@@ -155,8 +155,19 @@ export class ConnectorService extends BaseService {
     public restartConnector(clusterId: number, connectorName: string, body: any): Promise<void> {
         this.logger.info("[ConnectorService] Restart the connector");
 
-        const endpoint: string = this.endpoint("/connectors/:clusterId/:connectorName", { clusterId, connectorName });
-        return this.httpPost(endpoint, body);
+        const endpoint: string = this.endpoint("/connector/:clusterId/:connectorName/restart", { clusterId, connectorName });
+        return this.httpPut(endpoint, body);
+    }    
+
+    /**
+     * Restart the Connector Task for the supplied clusterId and connector
+     */
+    public restartConnectorTask(clusterId: number, connectorName: string, connectorTaskId: number, body: any): Promise<void> {
+        this.logger.info("[ConnectorService] Restart the connector task");
+
+        const endpoint: string = this.endpoint("/connector/:clusterId/:connectorName/task/:connectorTaskId/restart", 
+                                                { clusterId, connectorName, connectorTaskId });
+        return this.httpPut(endpoint, body);
     }    
 
 }

--- a/ui/packages/ui/src/app/pages/connectors/ConnectorsTableComponent.tsx
+++ b/ui/packages/ui/src/app/pages/connectors/ConnectorsTableComponent.tsx
@@ -117,6 +117,7 @@ export const ConnectorsTableComponent: React.FunctionComponent<IConnectorsTableC
       .pauseConnector(appLayoutContext.clusterId, connectorToPause, {})
       .then((cConnectors: any) => {
         addAlert("success", t('connectorPausedSuccess'));
+        setConnectorStatus(connectorToPause, "PAUSED");
       })
       .catch((err: React.SetStateAction<Error>) => {
         addAlert("danger",t('connectorPauseFailed'), err?.message);
@@ -136,6 +137,7 @@ export const ConnectorsTableComponent: React.FunctionComponent<IConnectorsTableC
       .resumeConnector(appLayoutContext.clusterId, connectorToResume, {})
       .then((cConnectors: any) => {
         addAlert("success", t('connectorResumedSuccess'));
+        setConnectorStatus(connectorToPause, "RUNNING");
       })
       .catch((err: React.SetStateAction<Error>) => {
         addAlert("danger",t('connectorResumeFailed'), err?.message);
@@ -155,6 +157,7 @@ export const ConnectorsTableComponent: React.FunctionComponent<IConnectorsTableC
       .restartConnector(appLayoutContext.clusterId, connectorToRestart, {})
       .then((cConnectors: any) => {
         addAlert("success", t('connectorRestartSuccess'));
+        setConnectorStatus(connectorToPause, "RUNNING");
       })
       .catch((err: React.SetStateAction<Error>) => {
         addAlert("danger",t('connectorRestartFailed'), err?.message);
@@ -201,6 +204,26 @@ export const ConnectorsTableComponent: React.FunctionComponent<IConnectorsTableC
     return taskElements;
   };
   
+  /**
+   * Immediately update the specified connector status in the table
+   * @param connName the connector
+   * @param status the new status
+   */
+  const setConnectorStatus = (connName: string, status: "PAUSED" | "RUNNING" ) => {
+    const updatedRows = [...connectors];
+    let doUpdateTable = false;
+    for (const conn of updatedRows) {
+      if (conn.name === connName && conn.connectorStatus !== status) {
+        conn.connectorStatus = status;
+        doUpdateTable = true;
+        break;
+      }
+    }
+    if (doUpdateTable) {
+      updateTableRows(updatedRows);
+    }
+  }
+
   React.useEffect(() => {
     const timeout = setTimeout(
       removeAlert,
@@ -332,9 +355,7 @@ export const ConnectorsTableComponent: React.FunctionComponent<IConnectorsTableC
           setConnectorToRestart(rowData.connName);
           showRestartConfirmationDialog();
         },
-        isDisabled: row.connStatus === "FAILED" 
-                    || row.connStatus === "UNASSIGNED"  
-                    || row.connStatus === "DESTROYED" ? false : true 
+        isDisabled: (row.connStatus === "UNASSIGNED" || row.connStatus === "DESTROYED") ? true : false 
       },
       {
         isSeparator: true


### PR DESCRIPTION
- updates the connector state lifecycle service methods and adds the task method
- update the restart action enablement - should always be enabled
- add function in ConnectorsTableComponent which changes a connector state immediately upon success of the lifecycle change instead of waiting for periodic refresh