### PR TITLE
DBZ-3054 Improve connector type display

### DIFF
--- a/ui/packages/ui/src/app/pages/createConnector/CreateConnectorComponent.tsx
+++ b/ui/packages/ui/src/app/pages/createConnector/CreateConnectorComponent.tsx
@@ -718,7 +718,11 @@ export const CreateConnectorComponent: React.FunctionComponent<ICreateConnectorC
         name: FILTER_CONFIGURATION_STEP,
         component: (
           <>
-            <ConnectorNameTypeHeader connectorName={getConnectorName()} connectorType={selectedConnectorType} />
+            <ConnectorNameTypeHeader 
+              connectorName={getConnectorName()} 
+              connectorType={selectedConnectorType} 
+              showIcon={false}
+            />
             <FilterConfigComponent
               propertyValues={
                 new Map([...basicPropValues, ...advancedPropValues])
@@ -738,7 +742,11 @@ export const CreateConnectorComponent: React.FunctionComponent<ICreateConnectorC
         name: DATA_OPTIONS_STEP,
         component: (
           <>
-            <ConnectorNameTypeHeader connectorName={getConnectorName()} connectorType={selectedConnectorType} />
+            <ConnectorNameTypeHeader 
+              connectorName={getConnectorName()} 
+              connectorType={selectedConnectorType} 
+              showIcon={false}
+            />
             <DataOptionsComponent
               propertyDefinitions={getDataOptionsPropertyDefinitions(
                 selectedConnectorPropertyDefns
@@ -781,7 +789,11 @@ export const CreateConnectorComponent: React.FunctionComponent<ICreateConnectorC
         name: RUNTIME_OPTIONS_STEP,
         component: (
           <>
-            <ConnectorNameTypeHeader connectorName={getConnectorName()} connectorType={selectedConnectorType} />
+            <ConnectorNameTypeHeader 
+              connectorName={getConnectorName()} 
+              connectorType={selectedConnectorType} 
+              showIcon={false}
+            />
             <RuntimeOptionsComponent
               propertyDefinitions={getRuntimeOptionsPropertyDefinitions(
                 selectedConnectorPropertyDefns
@@ -826,7 +838,11 @@ export const CreateConnectorComponent: React.FunctionComponent<ICreateConnectorC
     name: REVIEW_STEP,
     component: (
       <>
-        <ConnectorNameTypeHeader connectorName={getConnectorName()} connectorType={selectedConnectorType} />
+        <ConnectorNameTypeHeader 
+          connectorName={getConnectorName()} 
+          connectorType={selectedConnectorType} 
+          showIcon={false}
+        />
         <ReviewStepComponent
           i18nReviewMessage={t("reviewMessage", {
             connectorName: getConnectorName(),

--- a/ui/packages/ui/src/app/pages/createConnector/connectorSteps/ConnectorNameTypeHeader.css
+++ b/ui/packages/ui/src/app/pages/createConnector/connectorSteps/ConnectorNameTypeHeader.css
@@ -1,13 +1,4 @@
-.connector-name-type-header_name_label{
-  font-size: var(--pf-global--FontSize--l);
-  font-weight: var(--pf-global--FontWeight--bold);;
+.connector-name-type-header_divider{
+  margin-left: 10px;
   margin-right: 10px;
-  margin-bottom: 5px;
-}
-.connector-name-type-header_type_label{
-  font-size: var(--pf-global--FontSize--l);
-  font-weight: var(--pf-global--FontWeight--bold);;
-  margin-left: 20px;
-  margin-right: 5px;
-  margin-bottom: 5px;
 }

--- a/ui/packages/ui/src/app/pages/createConnector/connectorSteps/ConnectorNameTypeHeader.tsx
+++ b/ui/packages/ui/src/app/pages/createConnector/connectorSteps/ConnectorNameTypeHeader.tsx
@@ -12,6 +12,7 @@ import { ConnectorTypeComponent } from './ConnectorTypeComponent';
 export interface IConnectorNameTypeHeaderProps {
   connectorName?: string;
   connectorType?: string;
+  showIcon: boolean;
 }
 
 export const ConnectorNameTypeHeader: React.FunctionComponent<IConnectorNameTypeHeaderProps> = (
@@ -22,23 +23,16 @@ export const ConnectorNameTypeHeader: React.FunctionComponent<IConnectorNameType
     <Split>
       <SplitItem>
         <TextContent>
-          <Text className={"connector-name-type-header_name_label"}>
-            Connector name:
-          </Text>
-        </TextContent>
-      </SplitItem>
-      <SplitItem>
-        <TextContent>
           <Text component={TextVariants.p}>{props.connectorName}</Text>
         </TextContent>
       </SplitItem>
       <SplitItem>
         <TextContent>
-          <Text className={"connector-name-type-header_type_label"}>Type:</Text>
+          <Text className={"connector-name-type-header_divider"}>|</Text>
         </TextContent>
       </SplitItem>
       <SplitItem>
-        <ConnectorTypeComponent connectorType={props.connectorType} />
+        <ConnectorTypeComponent connectorType={props.connectorType} showIcon={props.showIcon}/>
       </SplitItem>
     </Split>
   );

--- a/ui/packages/ui/src/app/pages/createConnector/connectorSteps/ConnectorTypeComponent.tsx
+++ b/ui/packages/ui/src/app/pages/createConnector/connectorSteps/ConnectorTypeComponent.tsx
@@ -14,6 +14,7 @@ import "./ConnectorTypeComponent.css";
 
 export interface IConnectorTypeComponentProps {
   connectorType?: string;
+  showIcon: boolean;
 }
 
 export const ConnectorTypeComponent: React.FunctionComponent<IConnectorTypeComponentProps> = (
@@ -35,7 +36,7 @@ export const ConnectorTypeComponent: React.FunctionComponent<IConnectorTypeCompo
 
   return (
     <Split>
-      {props.connectorType ? (
+      {props.showIcon && props.connectorType ? (
         <SplitItem className="connector-type-icon">
           <ConnectorIcon
             connectorType={props.connectorType}

--- a/ui/packages/ui/src/app/pages/createConnector/connectorSteps/PropertiesStep.css
+++ b/ui/packages/ui/src/app/pages/createConnector/connectorSteps/PropertiesStep.css
@@ -4,7 +4,6 @@
 .connector-type-label {
   font-weight: var(--pf-c-form__label-text--FontWeight);
   font-size: var(--pf-c-form__label--FontSize);
-  margin-top: 3px;
   margin-right: 10px;
 }
 .properties-step {

--- a/ui/packages/ui/src/app/pages/createConnector/connectorSteps/PropertiesStep.tsx
+++ b/ui/packages/ui/src/app/pages/createConnector/connectorSteps/PropertiesStep.tsx
@@ -227,6 +227,7 @@ export const PropertiesStep: React.FC<any> = React.forwardRef(
                     <SplitItem>
                       <ConnectorTypeComponent
                         connectorType={props.connectorType}
+                        showIcon={false}
                       />
                     </SplitItem>
                   </Split>


### PR DESCRIPTION
Simplified display of connector type in the wizard, per UX request.
- type icon is no longer shown (added 'showIcon' property to components to allow hide or show)
- simplified the name / type displayed at top of wizard pages to remove the bold labels, added divider


**Properties step screenshot:**
![props-cType](https://user-images.githubusercontent.com/1820403/107277253-c1052a80-6a19-11eb-9654-ba108be3bf19.png)


**Steps 3+ screenshot:**
![subsequent-nameType](https://user-images.githubusercontent.com/1820403/107277323-d2e6cd80-6a19-11eb-85c3-7b47f6e2f7ea.png)
