### PR TITLE
added white-space to pre tag in server error msg detail

### DIFF
--- a/ui/packages/ui/src/app/components/ApplicationErrorPage.css
+++ b/ui/packages/ui/src/app/components/ApplicationErrorPage.css
@@ -14,4 +14,7 @@
 .application-error-page > div.application-error-page_details > div {
     border: 1px solid #ccc;
 }
+.application-error-msg_error_msg{
+    white-space: pre-wrap;
+}
 

--- a/ui/packages/ui/src/app/components/ApplicationErrorPage.tsx
+++ b/ui/packages/ui/src/app/components/ApplicationErrorPage.tsx
@@ -38,7 +38,7 @@ export const ApplicationErrorPage: React.FC<IApplicationErrorPageProps> = (
     const msg = props.errorInfo ? props.errorInfo.componentStack
                   : props.error ? JSON.stringify(props.error) : t('noDetailsAvailable');
     return (
-      <Text component={"pre"} className={"pf-u-text-align-left"}>
+      <Text component={"pre"} className={"pf-u-text-align-left application-error-msg_error_msg"}>
         {msg}
       </Text>
     );


### PR DESCRIPTION
Added the white-space to the `pre` tag so that the error detail msg does not print in long-line. 
screenshot
![image](https://user-images.githubusercontent.com/8264372/107507297-5ee92880-6bc5-11eb-9db4-620164f06b0c.png)
